### PR TITLE
eval alt

### DIFF
--- a/pino.js
+++ b/pino.js
@@ -34,28 +34,25 @@ function sermon (stream, opts) {
   }
 
   for (var key in levels) {
-    // needed because we cannot put arguments manipulation
-    // in another function without paying a perf drop
+    funcs[key] = function plog (a, b, c, d, e, f, g, h, i, j, k) {
+      var base = 0
+      var obj = null
+      var params = null
+      var msg
+      if (Object(a) === a) {
+        obj = a
+        params = [b, c, d, e, f, g, h, i, j, k]
+        base = 1
+      } else {
+        params = [a, b, c, d, e, f, g, h, i, j, k]
+      }
+      if ((params.length = arguments.length - base) > 0) {
+        msg = format.apply(null, params)
+      }
 
-    eval('' + // eslint-disable-line no-eval
-      'funcs.' + key + ' = function ' + key + ' () {\n' +
-      '  var base = 0\n' +
-      '  var obj = null\n' +
-      '  var msg // so it does not happear in the json\n' +
-      '  if (is.isObject(arguments[0])) {\n' +
-      '    obj = arguments[0]\n' +
-      '    base += 1\n' +
-      '  }\n' +
-      '  var toFormat = new Array(arguments.length - base)\n' +
-      '  for (var i = base; i < arguments.length; i++) {\n' +
-      '    toFormat[i - base] = arguments[i]\n' +
-      '  }\n' +
-      '  if (toFormat.length > 0) {\n' +
-      '    msg = format.apply(null, toFormat)\n' +
-      '  }\n' +
-      '  stream.write(asJson(obj, msg, ' + levels[key] + ' ))\n' +
-      '}'
-    )
+      stream.write(asJson(obj, msg, plog.level))
+    }
+    funcs[key].level = levels[key]
   }
 
   Object.defineProperty(result, 'level', {


### PR DESCRIPTION
On average I think we're losing maybe 15-30ms by not using eval, however I think there's more room to optimise here (seeing some deopts in both cases, e.g. not a Smi and Unexpected Object). Also util.format is unoptimizable so we might want to rewrite that part too. 

The trade off here is using eval vs limited args and possibly up to 30ms hit (quite a lot - could be optimized more though - also we're still miles ahead). Not using eval may help adoption. 

```sh
with eval:
benchPino*10000: 467.518ms
benchPinoObj*10000: 515.426ms
benchPino*10000: 408.458ms
benchPinoObj*10000: 500.840ms

without:
benchPino*10000: 461.231ms
benchPinoObj*10000: 525.623ms
benchPino*10000: 440.931ms
benchPinoObj*10000: 513.321ms
```