### PR TITLE
20-25% speed increase

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,22 +145,22 @@ If more args follows `msg`, these will be used to format `msg` using
 As far as I know, it is the fastest logger in town:
 
 ```
-benchBunyan*10000: 1128ms
-benchWinston*10000: 1903ms
-benchBole*10000: 1511ms
-benchPino*10000: 439ms
-benchBunyanObj*10000: 1209ms
-benchWinstonObj*10000: 1948ms
-benchPinoObj*10000: 526ms
-benchBoleObj*10000: 1466ms
-benchBunyan*10000: 1064ms
-benchWinston*10000: 1827ms
-benchBole*10000: 1524ms
-benchPino*10000: 438ms
-benchBunyanObj*10000: 1220ms
-benchWinstonObj*10000: 2119ms
-benchPinoObj*10000: 524ms
-benchBoleObj*10000: 1522ms
+benchBunyan*10000: 1116.721ms
+benchWinston*10000: 1783.362ms
+benchBole*10000: 1496.580ms
+benchPino*10000: 363.430ms
+benchBunyanObj*10000: 1228.538ms
+benchWinstonObj*10000: 1895.251ms
+benchPinoObj*10000: 427.989ms
+benchBoleObj*10000: 1487.543ms
+benchBunyan*10000: 1088.231ms
+benchWinston*10000: 1733.589ms
+benchBole*10000: 1514.004ms
+benchPino*10000: 377.418ms
+benchBunyanObj*10000: 1205.833ms
+benchWinstonObj*10000: 1800.594ms
+benchPinoObj*10000: 412.170ms
+benchBoleObj*10000: 1522.469ms
 ```
 
 <a name="rotate"></a>

--- a/pino.js
+++ b/pino.js
@@ -91,7 +91,7 @@ function pino (opts, stream) {
     if (!msg && obj instanceof Error) {
       msg = obj.message
     }
-    var data = JSON.stringify(new Message(num, msg))
+    var data = message(num, msg)
     if (obj) {
       data = data.slice(0, data.length - 1)
 
@@ -109,14 +109,14 @@ function pino (opts, stream) {
     return data + '\n'
   }
 
-  function Message (level, msg) {
-    this.pid = pid
-    this.hostname = hostname
-    this.name = name
-    this.level = level
-    this.msg = msg && msg.toString()
-    this.time = new Date()
-    this.v = 0
+  function message (level, msg) {
+    return '{"pid":' + pid + ',' +
+      (typeof hostname === 'undefined' ? '' : '"hostname":"' + hostname + '",') +
+      (typeof name === 'undefined' ? '' : '"name":"' + name + '",') +
+      '"level":' + level + ',' +
+      (typeof msg === 'undefined' ? '' : '"msg":"' + (msg && msg.toString()) + '",') +
+      '"time":"' + (new Date()).toISOString() + '",' +
+      '"v":' + 0 + '}'
   }
 }
 


### PR DESCRIPTION
Flamegraph shows the bottleneck as stringify (from JSON.stringify): 

<img width="1315" alt="screen shot 2016-03-07 at 12 19 02" src="https://cloud.githubusercontent.com/assets/1190716/13569317/4d3e9932-e45f-11e5-965b-922de44bd2c4.png">

We can also see the stringify function is not optimized (hence, slow) 

By manually creating the initial string, we remove the stringify bottleneck

<img width="801" alt="screen shot 2016-03-07 at 12 26 23" src="https://cloud.githubusercontent.com/assets/1190716/13569414/e3ef3120-e45f-11e5-9c8b-88408795c77f.png">

This yields savings of between 20 and 25% 

benchPino*10000: 474.112ms
benchPino2*10000: 364.575ms
benchPinoObj*10000: 525.585ms
benchPinoObj2*10000: 413.634ms
benchPino*10000: 452.948ms
benchPino2*10000: 368.059ms
benchPinoObj*10000: 526.269ms
benchPinoObj2*10000: 428.568ms

