### PR TITLE
No slowdown when logging through child loggers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
+
+# 0x
+.__browserify_string_empty.js
+profile-*

--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ var instance = pino({
 ```
 
 <a name="child"></a>
-### logger.child(opts)
+### logger.child(bindings)
 
-Creates a child logger, setting all key-value pairs is `opts` as
+Creates a child logger, setting all key-value pairs in `bindings` as
 properties in the log lines. All serializers will be applied to the
 given pair.
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Into this:
 ## API
 
   * <a href="#constructor"><code><b>pino()</b></code></a>
+  * <a href="#child"><code>logger.<b>child()</b></code></a>
   * <a href="#level"><code>logger.<b>level</b></code></a>
   * <a href="#fatal"><code>logger.<b>fatal()</b></code></a>
   * <a href="#error"><code>logger.<b>error()</b></code></a>
@@ -152,6 +153,25 @@ var instance = pino({
   }
 }
 ```
+
+<a name="child"></a>
+### logger.child(opts)
+
+Creates a child logger, setting all key-value pairs is `opts` as
+properties in the log lines. All serializers will be applied to the
+given pair.
+
+Example:
+
+```js
+logger.child({ a: 'property' }).info('hello child!')
+// generates
+// {"pid":46497,"hostname":"MacBook-Pro-di-Matteo.local","level":30,"msg":"hello child!","time":1458124707120,"v":0,"a":"property"}
+```
+
+It leverage the output stream of the parent and
+its log level. These settings are immutable and pulled out during the
+instantiation of the child logger.
 
 <a name="level"></a>
 ### logger.level

--- a/benchmarks/basic.js
+++ b/benchmarks/basic.js
@@ -1,0 +1,55 @@
+'use strict'
+
+var bench = require('fastbench')
+var pino = require('../')
+var bunyan = require('bunyan')
+var bole = require('bole')('bench')
+var winston = require('winston')
+var fs = require('fs')
+var dest = fs.createWriteStream('/dev/null')
+var plog = pino(dest)
+var max = 10
+var blog = bunyan.createLogger({
+  name: 'myapp',
+  streams: [{
+    level: 'trace',
+    stream: dest
+  }]
+})
+
+require('bole').output({
+  level: 'info',
+  stream: dest
+})
+
+winston.add(winston.transports.File, { filename: '/dev/null' })
+winston.remove(winston.transports.Console)
+
+var run = bench([
+  function benchBunyan (cb) {
+    for (var i = 0; i < max; i++) {
+      blog.info('hello world')
+    }
+    setImmediate(cb)
+  },
+  function benchWinston (cb) {
+    for (var i = 0; i < max; i++) {
+      winston.info('hello world')
+    }
+    setImmediate(cb)
+  },
+  function benchBole (cb) {
+    for (var i = 0; i < max; i++) {
+      bole.info('hello world')
+    }
+    setImmediate(cb)
+  },
+  function benchPino (cb) {
+    for (var i = 0; i < max; i++) {
+      plog.info('hello world')
+    }
+    setImmediate(cb)
+  }
+], 10000)
+
+run(run)

--- a/benchmarks/child.js
+++ b/benchmarks/child.js
@@ -1,0 +1,45 @@
+'use strict'
+
+var bench = require('fastbench')
+var pino = require('../')
+var bunyan = require('bunyan')
+var bole = require('bole')('bench')('child')
+var fs = require('fs')
+var dest = fs.createWriteStream('/dev/null')
+var plog = pino(dest).child({ a: 'property' })
+var max = 10
+var blog = bunyan.createLogger({
+  name: 'myapp',
+  streams: [{
+    level: 'trace',
+    stream: dest
+  }]
+}).child({ a: 'property' })
+
+require('bole').output({
+  level: 'info',
+  stream: dest
+})
+
+var run = bench([
+  function benchBunyanObj (cb) {
+    for (var i = 0; i < max; i++) {
+      blog.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  },
+  function benchPinoChild (cb) {
+    for (var i = 0; i < max; i++) {
+      plog.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  },
+  function benchBoleChild (cb) {
+    for (var i = 0; i < max; i++) {
+      bole.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  }
+], 10000)
+
+run(run)

--- a/benchmarks/childCreation.js
+++ b/benchmarks/childCreation.js
@@ -1,0 +1,48 @@
+'use strict'
+
+var bench = require('fastbench')
+var pino = require('../')
+var bunyan = require('bunyan')
+var bole = require('bole')('bench')
+var fs = require('fs')
+var dest = fs.createWriteStream('/dev/null')
+var plog = pino(dest)
+var max = 10
+var blog = bunyan.createLogger({
+  name: 'myapp',
+  streams: [{
+    level: 'trace',
+    stream: dest
+  }]
+})
+
+require('bole').output({
+  level: 'info',
+  stream: dest
+})
+
+var run = bench([
+  function benchPinoChild (cb) {
+    var child = plog.child({ a: 'property' })
+    for (var i = 0; i < max; i++) {
+      child.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  },
+  function benchBunyanObj (cb) {
+    var child = blog.child({ a: 'property' })
+    for (var i = 0; i < max; i++) {
+      child.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  },
+  function benchBoleChild (cb) {
+    var child = bole('child')
+    for (var i = 0; i < max; i++) {
+      child.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  }
+], 10000)
+
+run(run)

--- a/benchmarks/childCreation.js
+++ b/benchmarks/childCreation.js
@@ -22,21 +22,21 @@ require('bole').output({
 })
 
 var run = bench([
-  function benchPinoChild (cb) {
+  function benchPinoCreation (cb) {
     var child = plog.child({ a: 'property' })
     for (var i = 0; i < max; i++) {
       child.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
-  function benchBunyanObj (cb) {
+  function benchBunyanCreation (cb) {
     var child = blog.child({ a: 'property' })
     for (var i = 0; i < max; i++) {
       child.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
-  function benchBoleChild (cb) {
+  function benchBoleCreation (cb) {
     var child = bole('child')
     for (var i = 0; i < max; i++) {
       child.info({ hello: 'world' })

--- a/benchmarks/object.js
+++ b/benchmarks/object.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var bench = require('fastbench')
-var pino = require('./')
+var pino = require('../')
 var bunyan = require('bunyan')
 var bole = require('bole')('bench')
 var winston = require('winston')
@@ -26,30 +26,6 @@ winston.add(winston.transports.File, { filename: '/dev/null' })
 winston.remove(winston.transports.Console)
 
 var run = bench([
-  function benchBunyan (cb) {
-    for (var i = 0; i < max; i++) {
-      blog.info('hello world')
-    }
-    setImmediate(cb)
-  },
-  function benchWinston (cb) {
-    for (var i = 0; i < max; i++) {
-      winston.info('hello world')
-    }
-    setImmediate(cb)
-  },
-  function benchBole (cb) {
-    for (var i = 0; i < max; i++) {
-      bole.info('hello world')
-    }
-    setImmediate(cb)
-  },
-  function benchPino (cb) {
-    for (var i = 0; i < max; i++) {
-      plog.info('hello world')
-    }
-    setImmediate(cb)
-  },
   function benchBunyanObj (cb) {
     for (var i = 0; i < max; i++) {
       blog.info({ hello: 'world' })

--- a/example.js
+++ b/example.js
@@ -12,3 +12,5 @@ info({ obj: 42, b: 2 }, 'hello world')
 info({ obj: { aa: 'bbb' } }, 'another')
 setImmediate(info, 'after setImmediate')
 error(new Error('an error'))
+
+pino.child({ a: 'property' }).info('hello child!')

--- a/pino.js
+++ b/pino.js
@@ -147,16 +147,16 @@ function setup (result, funcs, level, stream, opts, serializers, stringify) {
   result.level = opts.level || 'info'
   result.child = child
 
-  function child (opts) {
+  function child (bindings) {
     if (!opts) {
-      throw new Error('missing options for child logger')
+      throw new Error('missing bindings for child logger')
     }
 
     var data = ''
     var value
-    for (var key in opts) {
-      value = opts[key]
-      if (opts.hasOwnProperty(key) && value !== undefined) {
+    for (var key in bindings) {
+      value = bindings[key]
+      if (bindings.hasOwnProperty(key) && value !== undefined) {
         value = serializers[key] ? serializers[key](value) : value
         data += '"' + key + '":' + stringify(value)
       }

--- a/pino.js
+++ b/pino.js
@@ -52,7 +52,7 @@ function pino (opts, stream) {
       }
     })
   } else {
-    setup(result, funcs, level, stream, opts)
+    setup(result, funcs, level, stream, opts, serializers, stringify)
   }
 
   return result
@@ -120,7 +120,7 @@ function pino (opts, stream) {
   }
 }
 
-function setup (result, funcs, level, stream, opts) {
+function setup (result, funcs, level, stream, opts, serializers, stringify) {
   var safe = opts.safe
 
   Object.defineProperty(result, 'level', {
@@ -152,13 +152,19 @@ function setup (result, funcs, level, stream, opts) {
       throw new Error('missing options for child logger')
     }
 
-    var meta = JSON.stringify(opts)
-    meta = meta.slice(0, meta.length - 1)
-    meta = meta.slice(1)
+    var data = ''
+    var value
+    for (var key in opts) {
+      value = opts[key]
+      if (opts.hasOwnProperty(key) && value !== undefined) {
+        value = serializers[key] ? serializers[key](value) : value
+        data += '"' + key + '":' + stringify(value)
+      }
+    }
 
     var toPino = {
       safe: safe,
-      meta: meta,
+      meta: data,
       level: level
     }
 

--- a/pino.js
+++ b/pino.js
@@ -165,7 +165,8 @@ function setup (result, funcs, level, stream, opts, serializers, stringify) {
     var toPino = {
       safe: safe,
       meta: data,
-      level: level
+      level: level,
+      serializers: serializers
     }
 
     return pino(toPino, stream)

--- a/pino.js
+++ b/pino.js
@@ -15,11 +15,6 @@ var levels = {
   trace: 10
 }
 
-var reverseLevels = Object.keys(levels).reduce(function (acc, key) {
-  acc[levels[key]] = key
-  return acc
-}, {})
-
 function pino (opts, stream) {
   if (opts && opts._writableState) {
     stream = opts
@@ -27,11 +22,10 @@ function pino (opts, stream) {
   }
   stream = stream || process.stdout
   opts = opts || {}
-  var safe = opts.safe
   var slowtime = opts.slowtime
-  var stringify = safe !== false ? stringifySafe : JSON.stringify
+  var stringify = opts.safe !== false ? stringifySafe : JSON.stringify
   var name = opts.name
-  var level
+  var level = opts.level
   var funcs = {}
   var result = {
     fatal: null,
@@ -42,57 +36,23 @@ function pino (opts, stream) {
     trace: null
   }
   var serializers = opts.serializers || {}
-  var meta = ''
   var end = '}\n'
 
   for (var key in levels) {
     funcs[key] = genLogFunction(key)
   }
 
-  Object.defineProperty(result, 'level', {
-    enumerable: false,
-    get: function () {
-      return level
-    },
-    set: function (l) {
-      level = levels[l]
-      if (!level) {
-        throw new Error('unknown level ' + l)
-      }
-
-      Object.keys(levels).forEach(function (key) {
-        if (level <= levels[key]) {
-          result[key] = funcs[key]
-        } else {
-          result[key] = noop
-        }
-      })
-    }
-  })
-
-  function child (meta) {
-    if (!meta) {
-      throw new Error('missing options for child logger')
-    }
-
-    var opts = {
-      safe: safe,
-      meta: meta,
-      level: reverseLevels[level]
-    }
-
-    return pino(opts, stream)
-  }
-
-  result.level = opts.level || 'info'
-
   if (opts.meta) {
-    meta = JSON.stringify(opts.meta)
-    meta = meta.slice(0, meta.length - 1)
-    meta = meta.slice(1)
-    end = ',' + meta + end
+    end = ',' + opts.meta + end
+    Object.keys(levels).forEach(function (key) {
+      if (level <= levels[key]) {
+        result[key] = funcs[key]
+      } else {
+        result[key] = noop
+      }
+    })
   } else {
-    result.child = child
+    setup(result, funcs, level, stream, opts)
   }
 
   return result
@@ -157,6 +117,52 @@ function pino (opts, stream) {
       (msg === undefined ? '' : '"msg":"' + (msg && msg.toString()) + '",') +
       '"time":' + (slowtime ? '"' + (new Date()).toISOString() + '"' : Date.now()) + ',' +
       '"v":' + 0
+  }
+}
+
+function setup (result, funcs, level, stream, opts) {
+  var safe = opts.safe
+
+  Object.defineProperty(result, 'level', {
+    enumerable: false,
+    get: function () {
+      return level
+    },
+    set: function (l) {
+      level = levels[l]
+      if (!level) {
+        throw new Error('unknown level ' + l)
+      }
+
+      Object.keys(levels).forEach(function (key) {
+        if (level <= levels[key]) {
+          result[key] = funcs[key]
+        } else {
+          result[key] = noop
+        }
+      })
+    }
+  })
+
+  result.level = opts.level || 'info'
+  result.child = child
+
+  function child (opts) {
+    if (!opts) {
+      throw new Error('missing options for child logger')
+    }
+
+    var meta = JSON.stringify(opts)
+    meta = meta.slice(0, meta.length - 1)
+    meta = meta.slice(1)
+
+    var toPino = {
+      safe: safe,
+      meta: meta,
+      level: level
+    }
+
+    return pino(toPino, stream)
   }
 }
 

--- a/test.js
+++ b/test.js
@@ -106,6 +106,28 @@ function levelTest (name, level) {
     instance.level = name
     instance[name](err)
   })
+
+  test('child logger for level ' + name, function (t) {
+    t.plan(2)
+    var instance = pino(sink(function (chunk, enc, cb) {
+      t.ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
+      delete chunk.time
+      t.deepEqual(chunk, {
+        pid: pid,
+        hostname: hostname,
+        level: level,
+        msg: 'hello world',
+        hello: 'world',
+        v: 0
+      })
+    }))
+
+    instance.level = name
+    var child = instance.child({
+      hello: 'world'
+    })
+    child[name]('hello world')
+  })
 }
 
 levelTest('fatal', 60)


### PR DESCRIPTION
@davidmarkclements and @danjenkins. Here you are.

Some notes (all bad):

1. creating a logger is going to be relatively _slow_ (might still be faster than bunyan)
2. the child logger does not inherits anything really, if you change the parent you are going to have issues
3. you can pass a `meta` property to any pino instance, and all the properties in there will be added
4. creating a child of a child does not work, currently
5. the data is made immutable when you create the logger, prejsonified it and stored

Good news: *there is no drawback*.

Any ideas on how to solve point 1-5?