### PR TITLE
5-10% inc

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,22 +59,22 @@ This produces:
 As far as we know, it is the fastest logger in town:
 
 ```
-benchBunyan*10000: 1093.236ms
-benchWinston*10000: 1904.147ms
-benchBole*10000: 1563.632ms
-benchPino*10000: 287.858ms
-benchBunyanObj*10000: 1187.016ms
-benchWinstonObj*10000: 1990.980ms
-benchPinoObj*10000: 366.865ms
-benchBoleObj*10000: 1475.934ms
-benchBunyan*10000: 1043.486ms
-benchWinston*10000: 1801.232ms
-benchBole*10000: 1524.136ms
-benchPino*10000: 280.797ms
-benchBunyanObj*10000: 1188.472ms
-benchWinstonObj*10000: 1868.626ms
-benchPinoObj*10000: 371.082ms
-benchBoleObj*10000: 1496.449ms
+benchBunyan*10000: 1075.649ms
+benchWinston*10000: 1840.185ms
+benchBole*10000: 1635.768ms
+benchPino*10000: 265.838ms
+benchBunyanObj*10000: 1250.343ms
+benchWinstonObj*10000: 1828.912ms
+benchPinoObj*10000: 357.569ms
+benchBoleObj*10000: 1594.823ms
+benchBunyan*10000: 1082.447ms
+benchWinston*10000: 1717.277ms
+benchBole*10000: 1591.113ms
+benchPino*10000: 260.141ms
+benchBunyanObj*10000: 1231.469ms
+benchWinstonObj*10000: 1807.529ms
+benchPinoObj*10000: 385.072ms
+benchBoleObj*10000: 1542.180ms
 ```
 
 

--- a/pino.js
+++ b/pino.js
@@ -73,6 +73,7 @@ function pino (opts, stream) {
       var obj = null
       var params = null
       var msg
+      var len
       if (typeof a === 'object' && a !== null) {
         obj = a
         params = [b, c, d, e, f, g, h, i, j, k]
@@ -86,8 +87,11 @@ function pino (opts, stream) {
       } else {
         params = [a, b, c, d, e, f, g, h, i, j, k]
       }
-      if ((params.length = arguments.length - base) > 0) {
+      len = params.length = arguments.length - base
+      if (len > 1) {
         msg = format.apply(null, params)
+      } else if (len) {
+        msg = params[0]
       }
 
       stream.write(asJson(obj, msg, level))


### PR DESCRIPTION
.apply cant be inlined - we're doing format.apply all the time

the thing is, we actually only ever need it if the first param is attempting interpolation, 
however using regexp to test whether a string contains '%' is just as expensive as just doing the format.apply. 

But - we can check if args length > 1 (instead of greater than 0), and then prioritise the 0 case by simply setting message to params[0]. This gives a 5-10% perf increase, bringing 10000 ops down to 260-265ms 


benchmarks:
```js
  function benchPino (cb) {
    for (var i = 0; i < max; i++) {
      plog.info('hello world')
    }
    setImmediate(cb)
  },
  function benchPino2 (cb) {
    for (var i = 0; i < max; i++) {
      plog2.info('hello world')
    }
    setImmediate(cb)
  },
  function benchPinoMultiArg (cb) {
    for (var i = 0; i < max; i++) {
      plog.info('hello', 'world')
    }
    setImmediate(cb)
  },
  function benchPino2MultiArg (cb) {
    for (var i = 0; i < max; i++) {
      plog2.info('hello', 'world')
    }
    setImmediate(cb)
  },
```

results at 10000 ops:

benchPino*10000: 319.005ms
benchPino2*10000: 268.181ms
benchPinoMultiArg*10000: 297.216ms
benchPino2MultiArg*10000: 283.411ms
benchPino*10000: 290.877ms
benchPino2*10000: 259.626ms
benchPinoMultiArg*10000: 295.353ms
benchPino2MultiArg*10000: 282.366ms

results at 50000 ops

benchPino*50000: 1334.496ms
benchPino2*50000: 1269.305ms
benchPinoMultiArg*50000: 1342.086ms
benchPino2MultiArg*50000: 1345.085ms
benchPino*50000: 1312.044ms
benchPino2*50000: 1269.279ms
benchPinoMultiArg*50000: 1343.235ms
benchPino2MultiArg*50000: 1354.008ms


full benchmark results: 

benchBunyan*10000: 1075.649ms
benchWinston*10000: 1840.185ms
benchBole*10000: 1635.768ms
benchPino*10000: 265.838ms
benchBunyanObj*10000: 1250.343ms
benchWinstonObj*10000: 1828.912ms
benchPinoObj*10000: 357.569ms
benchBoleObj*10000: 1594.823ms
benchBunyan*10000: 1082.447ms
benchWinston*10000: 1717.277ms
benchBole*10000: 1591.113ms
benchPino*10000: 260.141ms
benchBunyanObj*10000: 1231.469ms
benchWinstonObj*10000: 1807.529ms
benchPinoObj*10000: 385.072ms
benchBoleObj*10000: 1542.180ms

