### PR TITLE
roll our own format func

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,26 +58,32 @@ This produces:
 
 As far as we know, it is the fastest logger in town:
 
+`info('hello world')`:
+
 ```
-benchBunyan*10000: 1230ms
-benchWinston*10000: 2139ms
-benchBole*10000: 1615ms
-benchPino*10000: 314ms
-benchBunyan*10000: 1135ms
-benchWinston*10000: 2025ms
-benchBole*10000: 1635ms
-benchPino*10000: 312ms
-benchBunyanObj*10000: 1480ms
-benchWinstonObj*10000: 2252ms
-benchPinoObj*10000: 409ms
-benchBoleObj*10000: 1765ms
-benchBunyanObj*10000: 1415ms
-benchWinstonObj*10000: 2224ms
-benchPinoObj*10000: 400ms
-benchBoleObj*10000: 1739ms
-benchBunyanObj*10000: 1366ms
+benchBunyan*10000: 1115.193ms
+benchWinston*10000: 1722.497ms
+benchBole*10000: 1640.052ms
+benchPino*10000: 265.622ms
 ```
 
+`info({'hello': 'world'})`:
+
+```
+benchBunyanObj*10000: 1252.539ms
+benchWinstonObj*10000: 1729.837ms
+benchBoleObj*10000: 1491.677ms
+benchPinoObj*10000: 365.207ms
+```
+
+`info('hello %s %j %d', 'world', {obj: true}, 4, {another: 'obj'})`:
+
+benchBunyanInterpolateExtra*10000: 2607.519ms
+benchWinstonInterpolateExtra*10000: 2258.154ms
+benchBoleInterpolateExtra*10000: 3069.085ms
+benchPinoInterpolateExtra*10000: 450.634ms
+
+In multiple cases, pino is 6x faster than alternatives.
 
 <a name="cli"></a>
 ## CLI

--- a/benchmarks/multiArg.js
+++ b/benchmarks/multiArg.js
@@ -1,0 +1,121 @@
+'use strict'
+
+var bench = require('fastbench')
+var pino = require('../')
+var bunyan = require('bunyan')
+var bole = require('bole')('bench')
+var winston = require('winston')
+var fs = require('fs')
+var dest = fs.createWriteStream('/dev/null')
+var plog = pino(dest)
+var max = 10
+var blog = bunyan.createLogger({
+  name: 'myapp',
+  streams: [{
+    level: 'trace',
+    stream: dest
+  }]
+})
+
+require('bole').output({
+  level: 'info',
+  stream: dest
+})
+
+winston.add(winston.transports.File, { filename: '/dev/null' })
+winston.remove(winston.transports.Console)
+
+var run = bench([
+  function benchBunyanMulti (cb) {
+    for (var i = 0; i < max; i++) {
+      blog.info('hello', 'world')
+    }
+    setImmediate(cb)
+  },
+  function benchWinstonMulti (cb) {
+    for (var i = 0; i < max; i++) {
+      winston.info('hello', 'world')
+    }
+    setImmediate(cb)
+  },
+  function benchBoleMulti (cb) {
+    for (var i = 0; i < max; i++) {
+      bole.info('hello', 'world')
+    }
+    setImmediate(cb)
+  },
+  function benchPinoMulti (cb) {
+    for (var i = 0; i < max; i++) {
+      plog.info('hello', 'world')
+    }
+    setImmediate(cb)
+  },
+  function benchBunyanInterpolate (cb) {
+    for (var i = 0; i < max; i++) {
+      blog.info('hello %s', 'world')
+    }
+    setImmediate(cb)
+  },
+  function benchWinstonInterpolate (cb) {
+    for (var i = 0; i < max; i++) {
+      winston.info('hello %s', 'world')
+    }
+    setImmediate(cb)
+  },
+  function benchBoleInterpolate (cb) {
+    for (var i = 0; i < max; i++) {
+      bole.info('hello %s', 'world')
+    }
+    setImmediate(cb)
+  },
+  function benchBunyanInterpolateAll (cb) {
+    for (var i = 0; i < max; i++) {
+      blog.info('hello %s %j %d', 'world', {obj: true}, 4)
+    }
+    setImmediate(cb)
+  },
+  function benchWinstonInterpolateAll (cb) {
+    for (var i = 0; i < max; i++) {
+      winston.info('hello %s %j %d', 'world', {obj: true}, 4)
+    }
+    setImmediate(cb)
+  },
+  function benchBoleInterpolateAll (cb) {
+    for (var i = 0; i < max; i++) {
+      bole.info('hello %s %j %d', 'world', {obj: true}, 4)
+    }
+    setImmediate(cb)
+  },
+  function benchPinoInterpolateAll (cb) {
+    for (var i = 0; i < max; i++) {
+      plog.info('hello %s %j %d', 'world', {obj: true}, 4)
+    }
+    setImmediate(cb)
+  },
+  function benchBunyanInterpolateExtra (cb) {
+    for (var i = 0; i < max; i++) {
+      blog.info('hello %s %j %d', 'world', {obj: true}, 4, {another: 'obj'})
+    }
+    setImmediate(cb)
+  },
+  function benchWinstonInterpolateExtra (cb) {
+    for (var i = 0; i < max; i++) {
+      winston.info('hello %s %j %d', 'world', {obj: true}, 4, {another: 'obj'})
+    }
+    setImmediate(cb)
+  },
+  function benchBoleInterpolateExtra (cb) {
+    for (var i = 0; i < max; i++) {
+      bole.info('hello %s %j %d', 'world', {obj: true}, 4, {another: 'obj'})
+    }
+    setImmediate(cb)
+  },
+  function benchPinoInterpolateExtra (cb) {
+    for (var i = 0; i < max; i++) {
+      plog.info('hello %s %j %d', 'world', {obj: true}, 4, {another: 'obj'})
+    }
+    setImmediate(cb)
+  }
+], 10000)
+
+run(run)

--- a/benchmarks/object.js
+++ b/benchmarks/object.js
@@ -38,15 +38,15 @@ var run = bench([
     }
     setImmediate(cb)
   },
-  function benchPinoObj (cb) {
-    for (var i = 0; i < max; i++) {
-      plog.info({ hello: 'world' })
-    }
-    setImmediate(cb)
-  },
   function benchBoleObj (cb) {
     for (var i = 0; i < max; i++) {
       bole.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  },
+  function benchPinoObj (cb) {
+    for (var i = 0; i < max; i++) {
+      plog.info({ hello: 'world' })
     }
     setImmediate(cb)
   }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "core-util-is": "^1.0.2",
     "fast-json-parse": "^1.0.0",
     "json-stringify-safe": "^5.0.1",
+    "quick-format": "^1.0.0",
     "split2": "^2.0.1"
   }
 }

--- a/pino.js
+++ b/pino.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var stringifySafe = require('json-stringify-safe')
+var format = require('quick-format')
 var os = require('os')
 var pid = process.pid
 var hostname = os.hostname()
@@ -213,74 +214,3 @@ module.exports.stdSerializers = {
   req: asReqValue,
   res: asResValue
 }
-
-var inspect = require('util').inspect
-
-// Did not inline format called from  (target text too big).
-function format (args) {
-  var f = args[0]
-  var argLen = args.length
-
-  var str = ''
-  var a = 1
-  var lastPos = 0
-  for (var i = 0; i < f.length;) {
-    if (f.charCodeAt(i) === 37 && i + 1 < f.length) {
-      switch (f.charCodeAt(i + 1)) {
-        case 100: // 'd'
-          if (a >= argLen) { break }
-          if (lastPos < i) {
-            str += f.slice(lastPos, i)
-          }
-          str += Number(args[a++])
-          lastPos = i = i + 2
-          continue
-        case 106: // 'j'
-          if (a >= argLen) {
-            break
-          }
-          if (lastPos < i) {
-            str += f.slice(lastPos, i)
-          }
-          str += stringifySafe(args[a++])
-          lastPos = i = i + 2
-          continue
-        case 115: // 's'
-          if (a >= argLen) {
-            break
-          }
-          if (lastPos < i) {
-            str += f.slice(lastPos, i)
-          }
-          str += String(args[a++])
-          lastPos = i = i + 2
-          continue
-        case 37: // '%'
-          if (lastPos < i) {
-            str += f.slice(lastPos, i)
-          }
-          str += '%'
-          lastPos = i = i + 2
-          continue
-      }
-    }
-    ++i
-  }
-  if (lastPos === 0) {
-    str = f
-  } else if (lastPos < f.length) {
-    str += f.slice(lastPos)
-  }
-  while (a < argLen) {
-    var x = args[a++]
-    if (x === null || (typeof x !== 'object' && typeof x !== 'symbol')) {
-      str += ' ' + x
-    } else {
-      str += ' ' + inspect(x)
-    }
-  }
-  return str
-}
-
-// Did not inline format called from  (target AST is too large [early]).
-// function format(e){for(var t=e[0],c=e.length,i="",n=1,r=0,o=0;o<t.length;){if(37===t.charCodeAt(o)&&o+1<t.length)switch(t.charCodeAt(o+1)){case 100:if(n>=c)break;o>r&&(i+=t.slice(r,o)),i+=Number(e[n++]),r=o+=2;continue;case 106:if(n>=c)break;o>r&&(i+=t.slice(r,o)),i+=stringifySafe(e[n++]),r=o+=2;continue;case 115:if(n>=c)break;o>r&&(i+=t.slice(r,o)),i+=String(e[n++]),r=o+=2;continue;case 37:o>r&&(i+=t.slice(r,o)),i+="%",r=o+=2;continue}++o}for(0===r?i=t:r<t.length&&(i+=t.slice(r));c>n;){var a=e[n++];i+=null===a||"object"!=typeof a&&"symbol"!=typeof a?" "+a:" "+inspect(a)}return i}

--- a/pino.js
+++ b/pino.js
@@ -1,7 +1,6 @@
 'use strict'
 
 var stringifySafe = require('json-stringify-safe')
-var format = require('util').format
 var os = require('os')
 var pid = process.pid
 var hostname = os.hostname()
@@ -89,7 +88,7 @@ function pino (opts, stream) {
       }
       len = params.length = arguments.length - base
       if (len > 1) {
-        msg = format.apply(null, params)
+        msg = format(params)
       } else if (len) {
         msg = params[0]
       }
@@ -170,3 +169,74 @@ module.exports.stdSerializers = {
   req: asReqValue,
   res: asResValue
 }
+
+var inspect = require('util').inspect
+
+// Did not inline format called from  (target text too big).
+function format (args) {
+  var f = args[0]
+  var argLen = args.length
+
+  var str = ''
+  var a = 1
+  var lastPos = 0
+  for (var i = 0; i < f.length;) {
+    if (f.charCodeAt(i) === 37 && i + 1 < f.length) {
+      switch (f.charCodeAt(i + 1)) {
+        case 100: // 'd'
+          if (a >= argLen) { break }
+          if (lastPos < i) {
+            str += f.slice(lastPos, i)
+          }
+          str += Number(args[a++])
+          lastPos = i = i + 2
+          continue
+        case 106: // 'j'
+          if (a >= argLen) {
+            break
+          }
+          if (lastPos < i) {
+            str += f.slice(lastPos, i)
+          }
+          str += stringifySafe(args[a++])
+          lastPos = i = i + 2
+          continue
+        case 115: // 's'
+          if (a >= argLen) {
+            break
+          }
+          if (lastPos < i) {
+            str += f.slice(lastPos, i)
+          }
+          str += String(args[a++])
+          lastPos = i = i + 2
+          continue
+        case 37: // '%'
+          if (lastPos < i) {
+            str += f.slice(lastPos, i)
+          }
+          str += '%'
+          lastPos = i = i + 2
+          continue
+      }
+    }
+    ++i
+  }
+  if (lastPos === 0) {
+    str = f
+  } else if (lastPos < f.length) {
+    str += f.slice(lastPos)
+  }
+  while (a < argLen) {
+    var x = args[a++]
+    if (x === null || (typeof x !== 'object' && typeof x !== 'symbol')) {
+      str += ' ' + x
+    } else {
+      str += ' ' + inspect(x)
+    }
+  }
+  return str
+}
+
+// Did not inline format called from  (target AST is too large [early]).
+// function format(e){for(var t=e[0],c=e.length,i="",n=1,r=0,o=0;o<t.length;){if(37===t.charCodeAt(o)&&o+1<t.length)switch(t.charCodeAt(o+1)){case 100:if(n>=c)break;o>r&&(i+=t.slice(r,o)),i+=Number(e[n++]),r=o+=2;continue;case 106:if(n>=c)break;o>r&&(i+=t.slice(r,o)),i+=stringifySafe(e[n++]),r=o+=2;continue;case 115:if(n>=c)break;o>r&&(i+=t.slice(r,o)),i+=String(e[n++]),r=o+=2;continue;case 37:o>r&&(i+=t.slice(r,o)),i+="%",r=o+=2;continue}++o}for(0===r?i=t:r<t.length&&(i+=t.slice(r));c>n;){var a=e[n++];i+=null===a||"object"!=typeof a&&"symbol"!=typeof a?" "+a:" "+inspect(a)}return i}


### PR DESCRIPTION
this isn't ready for acceptance, more the beginning of an experiment

I've taken core's util format, altered as follows:

1) accept single param called "args", must be an array
2) do not support non-string args for first arg (util format does this, but who uses that??)
3) convert syntax to conform to standard linting

No conclusive savings as yet, but format is not inlining - target text too big

As an experiment I minified it, which solves target text too big, but instead we get: "target AST is too large [early]" 

Possibly decomposing into smaller funcs is the solution here, needs more tinkering