### PR TITLE
better serialization

### DIFF
--- a/benchmarks/multiArg.js
+++ b/benchmarks/multiArg.js
@@ -73,6 +73,12 @@ var run = bench([
     }
     setImmediate(cb)
   },
+  function benchPinoInterpolate (cb) {
+    for (var i = 0; i < max; i++) {
+      plog.info('hello %s', 'world')
+    }
+    setImmediate(cb)
+  },
   function benchBunyanInterpolateAll (cb) {
     for (var i = 0; i < max; i++) {
       blog.info('hello %s %j %d', 'world', {obj: true}, 4)

--- a/package.json
+++ b/package.json
@@ -39,9 +39,8 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "core-util-is": "^1.0.2",
-    "fast-json-parse": "^1.0.0",
-    "json-stringify-safe": "^5.0.1",
-    "quick-format": "^1.0.0",
+    "fast-safe-stringify": "^1.0.4",
+    "quick-format": "^2.0.0",
     "split2": "^2.0.1"
   }
 }

--- a/pino.js
+++ b/pino.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var stringifySafe = require('json-stringify-safe')
+var stringifySafe = require('fast-safe-stringify')
 var format = require('quick-format')
 var os = require('os')
 var pid = process.pid
@@ -23,7 +23,8 @@ function pino (opts, stream) {
   stream = stream || process.stdout
   opts = opts || {}
   var slowtime = opts.slowtime
-  var stringify = opts.safe !== false ? stringifySafe : JSON.stringify
+  var safe = opts.safe !== false
+  var stringify = safe ? stringifySafe : JSON.stringify
   var name = opts.name
   var level = opts.level
   var funcs = {}
@@ -80,7 +81,7 @@ function pino (opts, stream) {
       }
       len = params.length = arguments.length - base
       if (len > 1) {
-        msg = format(params)
+        msg = format(params, safe ? null : {lowres: true})
       } else if (len) {
         msg = params[0]
       }
@@ -120,7 +121,7 @@ function pino (opts, stream) {
       '"level":' + level + ',' +
       (msg === undefined ? '' : '"msg":"' + (msg && msg.toString()) + '",') +
       '"time":' + (slowtime ? '"' + (new Date()).toISOString() + '"' : Date.now()) + ',' +
-      '"v":' + 0
+      '"v":' + 1
   }
 }
 

--- a/test.js
+++ b/test.js
@@ -23,7 +23,7 @@ function check (t, chunk, level, msg) {
     hostname: hostname,
     level: level,
     msg: msg,
-    v: 0
+    v: 1
   })
 }
 
@@ -48,7 +48,7 @@ function levelTest (name, level) {
         hostname: hostname,
         level: level,
         hello: 'world',
-        v: 0
+        v: 1
       })
     }))
 
@@ -67,7 +67,7 @@ function levelTest (name, level) {
         level: level,
         msg: 'a string',
         hello: 'world',
-        v: 0
+        v: 1
       })
     }))
 
@@ -98,7 +98,7 @@ function levelTest (name, level) {
         type: 'Error',
         msg: err.message,
         stack: err.stack,
-        v: 0
+        v: 1
       })
       cb()
     }))
@@ -118,7 +118,7 @@ function levelTest (name, level) {
         level: level,
         msg: 'hello world',
         hello: 'world',
-        v: 0
+        v: 1
       })
     }))
 
@@ -202,7 +202,7 @@ test('set the name', function (t) {
       level: 60,
       name: 'hello',
       msg: 'this is fatal',
-      v: 0
+      v: 1
     })
     cb()
   }))
@@ -241,7 +241,7 @@ test('set undefined properties', function (t) {
       hostname: hostname,
       level: 30,
       hello: 'world',
-      v: 0
+      v: 1
     })
     cb()
   }))
@@ -260,7 +260,7 @@ test('set properties defined in the prototype chain', function (t) {
       hostname: hostname,
       level: 30,
       hello: 'world',
-      v: 0
+      v: 1
     })
     cb()
   }))
@@ -286,7 +286,7 @@ test('http request support', function (t) {
       hostname: hostname,
       level: 30,
       msg: 'my request',
-      v: 0,
+      v: 1,
       req: {
         method: originalReq.method,
         url: originalReq.url,
@@ -328,7 +328,7 @@ test('http request support via serializer', function (t) {
       hostname: hostname,
       level: 30,
       msg: 'my request',
-      v: 0,
+      v: 1,
       req: {
         method: originalReq.method,
         url: originalReq.url,
@@ -366,7 +366,7 @@ test('http response support', function (t) {
       hostname: hostname,
       level: 30,
       msg: 'my response',
-      v: 0,
+      v: 1,
       res: {
         statusCode: originalRes.statusCode,
         header: originalRes._header
@@ -405,7 +405,7 @@ test('http response support via a serializer', function (t) {
       hostname: hostname,
       level: 30,
       msg: 'my response',
-      v: 0,
+      v: 1,
       res: {
         statusCode: originalRes.statusCode,
         header: originalRes._header
@@ -454,7 +454,7 @@ test('http request support via serializer in a child', function (t) {
       hostname: hostname,
       level: 30,
       msg: 'my request',
-      v: 0,
+      v: 1,
       req: {
         method: originalReq.method,
         url: originalReq.url,


### PR DESCRIPTION
in our benchmarks there's no real gain or loss, however in terms of functionality we get better serialization of objects when using interpolation - formally any object with a circular reference would result in the whole object being serialized as [Circular]. Now we label circular references properly, but 2x faster than json-stringify-safe (instead using fast-safe-stringify). This is how we end up with roughly the same benchmarks (because we replace json-stringify-safe for pino and use it instead of tryStringify for quick-format). 

also log format version (v prop) is bumped since circular reference output is different

benchmarks: 

benchPinoMulti*10000: 311.975ms
benchPinoMulti2*10000: 293.021ms
benchPinoInterpolate*10000: 306.162ms
benchPinoInterpolate2*10000: 304.980ms
benchPinoInterpolateAll*10000: 448.825ms
benchPinoInterpolateAll2*10000: 434.358ms
benchPinoInterpolateExtra*10000: 537.417ms
benchPinoInterpolateExtra2*10000: 530.803ms
benchPinoInterpolateDeep*10000: 5872.619ms
benchPinoInterpolateDeep2*10000: 5894.609ms
benchPinoMulti*10000: 287.413ms
benchPinoMulti2*10000: 289.061ms
benchPinoInterpolate*10000: 304.053ms
benchPinoInterpolate2*10000: 300.175ms
benchPinoInterpolateAll*10000: 467.555ms
benchPinoInterpolateAll2*10000: 451.627ms
benchPinoInterpolateExtra*10000: 582.479ms
benchPinoInterpolateExtra2*10000: 572.805ms
benchPinoInterpolateDeep*10000: 5850.142ms
benchPinoInterpolateDeep2*10000: 5877.385ms