### PR TITLE
+10-20% child creation, +7-8% basic/child logging, JSON output fix, sub-child loggers

### DIFF
--- a/benchmarks/child-child.js
+++ b/benchmarks/child-child.js
@@ -1,0 +1,33 @@
+'use strict'
+
+var bench = require('fastbench')
+var pino = require('../')
+var bunyan = require('bunyan')
+var fs = require('fs')
+var dest = fs.createWriteStream('/dev/null')
+var plog = pino(dest).child({ a: 'property' }).child({sub: 'child'})
+var max = 10
+var blog = bunyan.createLogger({
+  name: 'myapp',
+  streams: [{
+    level: 'trace',
+    stream: dest
+  }]
+}).child({ a: 'property' }).child({sub: 'child'})
+
+var run = bench([
+  function benchBunyanChildChild (cb) {
+    for (var i = 0; i < max; i++) {
+      blog.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  },
+  function benchPinoChildChild (cb) {
+    for (var i = 0; i < max; i++) {
+      plog.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  }
+], 10000)
+
+run(run)

--- a/benchmarks/childChild.js
+++ b/benchmarks/childChild.js
@@ -1,0 +1,33 @@
+'use strict'
+
+var bench = require('fastbench')
+var pino = require('../')
+var bunyan = require('bunyan')
+var fs = require('fs')
+var dest = fs.createWriteStream('/dev/null')
+var plog = pino(dest).child({ a: 'property' }).child({sub: 'child'})
+var max = 10
+var blog = bunyan.createLogger({
+  name: 'myapp',
+  streams: [{
+    level: 'trace',
+    stream: dest
+  }]
+}).child({ a: 'property' }).child({sub: 'child'})
+
+var run = bench([
+  function benchBunyanChildChild (cb) {
+    for (var i = 0; i < max; i++) {
+      blog.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  },
+  function benchPinoChildChild (cb) {
+    for (var i = 0; i < max; i++) {
+      plog.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  }
+], 10000)
+
+run(run)

--- a/example.js
+++ b/example.js
@@ -1,16 +1,20 @@
 'use strict'
 
 var pino = require('./')()
-var info = pino.info
-var error = pino.error
 
-info('hello world')
-error('this is at error level')
-info('the answer is %d', 42)
-info({ obj: 42 }, 'hello world')
-info({ obj: 42, b: 2 }, 'hello world')
-info({ obj: { aa: 'bbb' } }, 'another')
-setImmediate(info, 'after setImmediate')
-error(new Error('an error'))
+pino.info('hello world')
+pino.error('this is at error level')
+pino.info('the answer is %d', 42)
+pino.info({ obj: 42 }, 'hello world')
+pino.info({ obj: 42, b: 2 }, 'hello world')
+pino.info({ obj: { aa: 'bbb' } }, 'another')
+setImmediate(function () {
+  pino.info('after setImmediate')
+})
+pino.error(new Error('an error'))
 
-pino.child({ a: 'property' }).info('hello child!')
+var child = pino.child({ a: 'property' })
+child.info('hello child!')
+
+var childsChild = child.child({ another: 'property' })
+childsChild.info('hello baby..')

--- a/pino.js
+++ b/pino.js
@@ -6,6 +6,8 @@ var os = require('os')
 var pid = process.pid
 var hostname = os.hostname()
 
+var LOG_VERSION = 1
+
 var levels = {
   fatal: 60,
   error: 50,
@@ -14,6 +16,10 @@ var levels = {
   debug: 20,
   trace: 10
 }
+var nums = Object.keys(levels).reduce(function (o, k) {
+  o[levels[k]] = k
+  return o
+}, {})
 
 function pino (opts, stream) {
   if (opts && opts._writableState) {
@@ -26,156 +32,108 @@ function pino (opts, stream) {
   var safe = opts.safe !== false
   var stringify = safe ? stringifySafe : JSON.stringify
   var name = opts.name
-  var level = opts.level
-  var funcs = {}
-  var result = {
-    fatal: null,
-    error: null,
-    warn: null,
-    info: null,
-    debug: null,
-    trace: null
-  }
+  var level = opts.level || 'info'
   var serializers = opts.serializers || {}
-  var end = '}\n'
+  var end = ',"v":' + LOG_VERSION + '}\n'
+  return new Pino(level, stream, serializers, stringify, end, name, hostname, slowtime, '')
+}
 
+function Pino (level, stream, serializers, stringify, end, name, hostname, slowtime, chindings) {
+  this.stream = stream
+  this.serializers = serializers
+  this.stringify = stringify
+  this.end = end
+  this.name = name
+  this.hostname = hostname
+  this.slowtime = slowtime
+  this.chindings = chindings
+  this._setLevel(level)
+}
+
+Pino.prototype.fatal = genLog(levels.fatal)
+Pino.prototype.error = genLog(levels.error)
+Pino.prototype.warn = genLog(levels.warn)
+Pino.prototype.info = genLog(levels.info)
+Pino.prototype.debug = genLog(levels.debug)
+Pino.prototype.trace = genLog(levels.trace)
+
+Pino.prototype._setLevel = function _setLevel (level) {
+  if (typeof level === 'number') { level = nums[level] }
+  this._level = levels[level]
+
+  if (!this._level) {
+    throw new Error('unknown level ' + level)
+  }
+
+  var num = levels[level]
   for (var key in levels) {
-    funcs[key] = genLogFunction(key)
-  }
-
-  if (opts.meta) {
-    end = ',' + opts.meta + end
-    Object.keys(levels).forEach(function (key) {
-      if (level <= levels[key]) {
-        result[key] = funcs[key]
-      } else {
-        result[key] = noop
-      }
-    })
-  } else {
-    setup(result, funcs, level, stream, opts, serializers, stringify)
-  }
-
-  return result
-
-  function genLogFunction (key) {
-    var level = levels[key]
-    return function (a, b, c, d, e, f, g, h, i, j, k) {
-      var base = 0
-      var obj = null
-      var params = null
-      var msg
-      var len
-      if (typeof a === 'object' && a !== null) {
-        obj = a
-        params = [b, c, d, e, f, g, h, i, j, k]
-        base = 1
-
-        if (obj.method && obj.headers && obj.socket) {
-          obj = mapHttpRequest(obj)
-        } else if (obj.statusCode) {
-          obj = mapHttpResponse(obj)
-        }
-      } else {
-        params = [a, b, c, d, e, f, g, h, i, j, k]
-      }
-      len = params.length = arguments.length - base
-      if (len > 1) {
-        msg = format(params, safe ? null : {lowres: true})
-      } else if (len) {
-        msg = params[0]
-      }
-
-      stream.write(asJson(obj, msg, level))
+    if (num > levels[key]) {
+      this[key] = noop
+    } else if (this[key] === noop) {
+      this[key] = Pino.prototype[key]
     }
-  }
-
-  function asJson (obj, msg, num) {
-    if (!msg && obj instanceof Error) {
-      msg = obj.message
-    }
-    var data = message(num, msg)
-    var value
-    if (obj) {
-      if (obj.stack) {
-        data += ',"type":"Error","stack":' + stringify(obj.stack)
-      } else {
-        for (var key in obj) {
-          value = obj[key]
-          if (obj.hasOwnProperty(key) && value !== undefined) {
-            value = serializers[key] ? serializers[key](value) : value
-            data += ',"' + key + '":' + stringify(value)
-          }
-        }
-      }
-    }
-    return data + end
-  }
-
-  // returns string json with final brace omitted
-  // the final brace is added by asJson
-  function message (level, msg) {
-    return '{"pid":' + pid + ',' +
-      (hostname === undefined ? '' : '"hostname":"' + hostname + '",') +
-      (name === undefined ? '' : '"name":"' + name + '",') +
-      '"level":' + level + ',' +
-      (msg === undefined ? '' : '"msg":"' + (msg && msg.toString()) + '",') +
-      '"time":' + (slowtime ? '"' + (new Date()).toISOString() + '"' : Date.now()) + ',' +
-      '"v":' + 1
   }
 }
 
-function setup (result, funcs, level, stream, opts, serializers, stringify) {
-  var safe = opts.safe
+Pino.prototype._getLevel = function _getLevel (level) {
+  return nums[this._level]
+}
 
-  Object.defineProperty(result, 'level', {
-    enumerable: false,
-    get: function () {
-      return level
-    },
-    set: function (l) {
-      level = levels[l]
-      if (!level) {
-        throw new Error('unknown level ' + l)
-      }
+Object.defineProperty(Pino.prototype, 'level', {
+  get: Pino.prototype._getLevel,
+  set: Pino.prototype._setLevel
+})
 
-      Object.keys(levels).forEach(function (key) {
-        if (level <= levels[key]) {
-          result[key] = funcs[key]
-        } else {
-          result[key] = noop
-        }
-      })
-    }
-  })
-
-  result.level = opts.level || 'info'
-  result.child = child
-
-  function child (bindings) {
-    if (!bindings) {
-      throw new Error('missing bindings for child logger')
-    }
-
-    var data = ''
-    var value
-    for (var key in bindings) {
-      value = bindings[key]
-      if (bindings.hasOwnProperty(key) && value !== undefined) {
-        value = serializers[key] ? serializers[key](value) : value
-        data += '"' + key + '":' + stringify(value)
-      }
-    }
-
-    var toPino = {
-      safe: safe,
-      meta: data,
-      level: level,
-      serializers: serializers
-    }
-
-    return pino(toPino, stream)
+Pino.prototype.asJson = function asJson (obj, msg, num) {
+  if (!msg && obj instanceof Error) {
+    msg = obj.message
   }
+  var data = this.message(num, msg)
+  var value
+  if (obj) {
+    if (obj.stack) {
+      data += ',"type":"Error","stack":' + this.stringify(obj.stack)
+    } else {
+      for (var key in obj) {
+        value = obj[key]
+        if (obj.hasOwnProperty(key) && value !== undefined) {
+          value = this.serializers[key] ? this.serializers[key](value) : value
+          data += ',"' + key + '":' + this.stringify(value)
+        }
+      }
+    }
+  }
+  return data + this.chindings + this.end
+}
+// returns string json with final brace omitted
+// the final brace is added by asJson
+Pino.prototype.message = function message (level, msg) {
+  return '{"pid":' + pid + ',' +
+    (this.hostname === undefined ? '' : '"hostname":"' + this.hostname + '",') +
+    (this.name === undefined ? '' : '"name":"' + this.name + '",') +
+    '"level":' + level + ',' +
+    (msg === undefined ? '' : '"msg":"' + (msg && msg.toString()) + '",') +
+    '"time":' + (this.slowtime ? '"' + (new Date()).toISOString() + '"' : Date.now())
+}
+
+Pino.prototype.child = function child (bindings) {
+  if (!bindings) {
+    throw new Error('missing bindings for child Pino')
+  }
+
+  var data = ','
+  var value
+  var key
+  for (key in bindings) {
+    value = bindings[key]
+    if (bindings.hasOwnProperty(key) && value !== undefined) {
+      value = this.serializers[key] ? this.serializers[key](value) : value
+      data += '"' + key + '":' + this.stringify(value) + ','
+    }
+  }
+  data = this.chindings + data.substr(0, data.length - 1)
+
+  return new Pino(this.level, this.stream, this.serializers, this.stringify, this.end, this.name, this.hostname, this.slowtime, data)
 }
 
 function noop () {}
@@ -214,6 +172,36 @@ function asErrValue (err) {
     type: err.constructor.name,
     message: err.message,
     stack: err.stack
+  }
+}
+
+function genLog (level) {
+  return function (a, b, c, d, e, f, g, h, i, j, k) {
+    var base = 0
+    var obj = null
+    var params = null
+    var msg
+    var len
+    if (typeof a === 'object' && a !== null) {
+      obj = a
+      params = [b, c, d, e, f, g, h, i, j, k]
+      base = 1
+
+      if (obj.method && obj.headers && obj.socket) {
+        obj = mapHttpRequest(obj)
+      } else if (obj.statusCode) {
+        obj = mapHttpResponse(obj)
+      }
+    } else {
+      params = [a, b, c, d, e, f, g, h, i, j, k]
+    }
+    len = params.length = arguments.length - base
+    if (len > 1) {
+      msg = format(params, null)
+    } else if (len) {
+      msg = params[0]
+    }
+    this.stream.write(this.asJson(obj, msg, level))
   }
 }
 


### PR DESCRIPTION
fixes #20
closes #19

Summary:

* child loggers of child loggers as many as you want with close to zero overhead
* 10-20% speed improvement in child creation
* 7-8% improvement in basic logging and child logging
* important JSON output fix (#20)
* improves express-pino-logger both requests per second and throughput by 15%


# child creation shows speed improvements of between 10%-20%:

## benchmarks/childCreation.js - old
benchPinoCreation*10000: 417ms
benchBunyanCreation*10000: 1345ms
benchBoleCreation*10000: 1584ms
benchPinoCreation*10000: 384ms
benchBunyanCreation*10000: 1277ms
benchBoleCreation*10000: 1572ms


## benchmarks/childCreation.js - new
benchPinoCreation*10000: 362ms
benchBunyanCreation*10000: 1291ms
benchBoleCreation*10000: 1547ms
benchPinoCreation*10000: 338ms
benchBunyanCreation*10000: 1275ms
benchBoleCreation*10000: 1527ms


# child logging benchmarks consistently showed a 7% speed up (basic benchmarks show this also)

## benchmarks/child.js - old
benchBunyanObj*10000: 1254ms
benchPinoChild*10000: 353ms
benchBoleChild*10000: 1484ms
benchBunyanObj*10000: 1207ms
benchPinoChild*10000: 339ms
benchBoleChild*10000: 1460ms


## benchmarks/child.js - new
benchBunyanObj*10000: 1260ms
benchPinoChild*10000: 329ms
benchBoleChild*10000: 1498ms
benchBunyanObj*10000: 1216ms
benchPinoChild*10000: 316ms
benchBoleChild*10000: 1473ms

# sub-child loggers zero overhead

(also tested with children of children of children, same, no perceivable impact)

## benchmarks/child-child.js
benchBunyanChildChild*10000: 1358ms
benchPinoChildChild*10000: 326ms
benchBunyanChildChild*10000: 1314ms
benchPinoChildChild*10000: 317ms

# basic benchmarks consistently show a 7-8% speed up

## benchmarks/basic.js - old
benchBunyan*10000: 1060ms
benchWinston*10000: 1825ms
benchBole*10000: 1642ms
benchPino*10000: 286ms
benchBunyan*10000: 1061ms
benchWinston*10000: 1718ms
benchBole*10000: 1590ms
benchPino*10000: 287ms

## benchmarks/basic.js - new
benchBunyan*10000: 1192ms
benchWinston*10000: 1909ms
benchBole*10000: 1547ms
benchPino*10000: 264ms
benchBunyan*10000: 1085ms
benchWinston*10000: 1793ms
benchBole*10000: 1508ms
benchPino*10000: 260ms



# object benchmarks roughly the same

multiple runs showed some differences but not conclusive enough to call it

# multi arg benchmarks are about the same


# express-pino-logger raw server benchmark 15% speed increase:

## old

```

Running 10s test @ http://localhost:3000
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     8.38ms    1.39ms  44.50ms   95.83%
    Req/Sec     6.02k   491.46     6.42k    91.00%
  119742 requests in 10.00s, 12.68MB read
Requests/sec:  11972.03
Transfer/sec:      1.27MB
```

## New
```
Running 10s test @ http://localhost:3000
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     7.14ms    1.25ms  42.43ms   97.29%
    Req/Sec     7.06k   557.69     7.53k    95.05%
  142014 requests in 10.10s, 15.03MB read
Requests/sec:  14060.12
Transfer/sec:      1.49MB
```
