### PR TITLE
60% perf increase !!

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ This has a couple of important caveats:
 * 4KB of spare RAM will be needed for logging
 * As opposed to the default mode, there is not a one-to-one relationship between calls to logging methods (e.g. `logger.info`) and writes to a log file (or log stream)
 * There is a possibility of the most recently buffered log messages being lost (up to 4KB of logs)
-  * For instance, a powercut will mean no logs are written 
+  * For instance, a powercut will mean up to 4KB of buffered logs will be lost
   * A sigkill (or other untrappable signal) will probably result in the same
   * If writing to a stream other than `process.stdout` or `process.stderr`, there is a slight possibility of lost logs or even partially written logs if the OS buffers don't have enough space, or something else is being written to the stream (or maybe some other reason we've not thought of)
 

--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ Returns a new logger. Allowed options are:
   default `true`
 * `name`: the name of the logger, default `undefined`
 * `serializers`: an object containing functions for custom serialization of objects. These functions should return an JSONifiable object and they should never throw
-* `slowtime`: Outputs ISO time stamps (`'2016-03-09T15:18:53.889Z'`) instead of Epoch time stamps (`1457536759176`). **WARNING**: This option carries a 25% performance drop, we recommend using default Epoch timestamps and transforming logs after if required. The `pino -t` command will do this for you (see [CLI](#cli))
-* `extreme`: Enables extreme mode, yields an additional 60% performance (from 250ms down to 100ms per 10000 ops). There are trade-off's should be understood before usage. See [Extreme mode explained](#extreme).
+* `slowtime`: Outputs ISO time stamps (`'2016-03-09T15:18:53.889Z'`) instead of Epoch time stamps (`1457536759176`). **WARNING**: This option carries a 25% performance drop, we recommend using default Epoch timestamps and transforming logs after if required. The `pino -t` command will do this for you (see [CLI](#cli)). default `false`.
+* `extreme`: Enables extreme mode, yields an additional 60% performance (from 250ms down to 100ms per 10000 ops). There are trade-off's should be understood before usage. See [Extreme mode explained](#extreme). default `false`
 
 `stream` is a Writable stream, defaults to `process.stdout`.
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@ It also includes a shell utility to pretty-print its log files.
 * [Usage](#usage)
 * [Benchmarks](#benchmarks)
 * [API](#api)
+* [Extreme mode explained](#extreme)
+* [How to use Pino with Express](#express)
 * [How do I rotate log files?](#rotate)
 * [How to use Transports with Pino](#transports)
 * [Caveats](#caveats)
 * [Changelog](#changelog)
+* [Team](#team)
 * [Acknowledgements](#acknowledgements)
 * [License](#license)
 
@@ -72,28 +75,31 @@ As far as we know, it is the fastest logger in town:
 `pino.info('hello world')`:
 
 ```
-benchBunyan*10000: 1005ms
-benchWinston*10000: 1810ms
-benchBole*10000: 1493ms
-benchPino*10000: 254ms
+benchBunyan*10000: 1082.896ms
+benchWinston*10000: 1707.665ms
+benchBole*10000: 1574.295ms
+benchPino*10000: 264.506ms
+benchPinoExreme*10000: 105.391ms
 ```
 
 `pino.info({'hello': 'world'})`:
 
 ```
-benchBunyanObj*10000: 1262ms
-benchWinstonObj*10000: 1979ms
-benchBoleObj*10000: 1545ms
-benchPinoObj*10000: 341ms
+benchBunyanObj*10000: 1213.984ms
+benchWinstonObj*10000: 1951.889ms
+benchBoleObj*10000: 1717.641ms
+benchPinoObj*10000: 322.118ms
+benchPinoExtremeObj*10000: 142.215ms
 ```
 
 `pino.info('hello %s %j %d', 'world', {obj: true}, 4, {another: 'obj'})`:
 
 ```
-benchBunyanInterpolateExtra*10000: 2747ms
-benchWinstonInterpolateExtra*10000: 2659ms
-benchBoleInterpolateExtra*10000: 3366ms
-benchPinoInterpolateExtra*10000: 548ms
+benchBunyanInterpolateExtra*10000: 2665.294ms
+benchWinstonInterpolateExtra*10000: 2455.395ms
+benchBoleInterpolateExtra*10000: 3291.087ms
+benchPinoInterpolateExtra*10000: 568.122ms
+benchPinoExtremeInterpolateExtra*10000: 341.009ms
 ```
 
 In multiple cases, pino is over 6x faster than alternatives.
@@ -157,6 +163,7 @@ Returns a new logger. Allowed options are:
 * `name`: the name of the logger, default `undefined`
 * `serializers`: an object containing functions for custom serialization of objects. These functions should return an JSONifiable object and they should never throw
 * `slowtime`: Outputs ISO time stamps (`'2016-03-09T15:18:53.889Z'`) instead of Epoch time stamps (`1457536759176`). **WARNING**: This option carries a 25% performance drop, we recommend using default Epoch timestamps and transforming logs after if required. The `pino -t` command will do this for you (see [CLI](#cli))
+* `extreme`: Enables extreme mode, yields an additional 60% performance (from 250ms down to 100ms per 10000 ops). There are trade-off's should be understood before usage. See [Extreme mode explained](#extreme).
 
 `stream` is a Writable stream, defaults to `process.stdout`.
 
@@ -221,32 +228,27 @@ var childChild = child.child({baby: true})
 Child logger creation is fast:
 
 ```
-benchPinoCreation*10000: 364ms
-benchBunyanCreation*10000: 1309ms
-benchBoleCreation*10000: 1621ms
-benchPinoCreation*10000: 350ms
-benchBunyanCreation*10000: 1295ms
-benchBoleCreation*10000: 1595ms
+benchBunyanCreation*10000: 1291.332ms
+benchBoleCreation*10000: 1630.542ms
+benchPinoCreation*10000: 352.330ms
+benchPinoExtremeCreation*10000: 102.282ms
 ```
 
 Logging through a child logger has little performance penalty:
 
 ```
-benchBunyanObj*10000: 1309ms
-benchPinoChild*10000: 335ms
-benchBoleChild*10000: 1487ms
-benchBunyanObj*10000: 1262ms
-benchPinoChild*10000: 331ms
-benchBoleChild*10000: 1473ms
+benchBunyanChild*10000: 1343.933ms
+benchBoleChild*10000: 1605.969ms
+benchPinoChild*10000: 334.573ms
+benchPinoExtremeChild*10000: 152.792ms
 ```
 
 Spawning children from children has negligible overhead:
 
 ```
-benchBunyanChildChild*10000: 1353ms
-benchPinoChildChild*10000: 332ms
-benchBunyanChildChild*10000: 1333ms
-benchPinoChildChild*10000: 334ms
+benchBunyanChildChild*10000: 1397.202ms
+benchPinoChildChild*10000: 338.930ms
+benchPinoExtremeChildChild*10000: 150.143ms
 ```
 
 <a name="level"></a>
@@ -384,6 +386,48 @@ Serializes an `Error` object if passed in as an property.
   "stack": "Error: an error\n    at Object.<anonymous> (/Users/matteo/Repositories/pino/example.js:16:7)\n    at Module._compile (module.js:435:26)\n    at Object.Module._extensions..js (module.js:442:10)\n    at Module.load (module.js:356:32)\n    at Function.Module._load (module.js:313:12)\n    at Function.Module.runMain (module.js:467:10)\n    at startup (node.js:136:18)\n    at node.js:963:3"
 }
 ```
+
+<a name="extreme"></a>
+## Extreme mode explained
+
+In essence, Extreme mode enables extreme performance by buffering log messages and writing them in larger chunks.
+
+This has a couple of important caveats:
+
+* 4KB of spare RAM will be needed for logging
+* As opposed to the default mode, there is not a one-to-one relationship between calls to logging methods (e.g. `logger.info`) and writes to a log file (or log stream)
+* There is a possibility of the most recently buffered log messages being lost (up to 4KB of logs)
+  * For instance, a powercut will mean no logs are written 
+  * A sigkill (or other untrappable signal) will probably result in the same
+  * If writing to a stream other than `process.stdout` or `process.stderr`, there is a slight possibility of lost logs or even partially written logs if the OS buffers don't have enough space, or something else is being written to the stream (or maybe some other reason we've not thought of)
+
+So in summary, only use extreme mode if you're doing an extreme amount of logging, and you're happy in some scenarios to lose the most recent logs.
+
+
+<a name="express"></a>
+## How to use Pino with Express
+
+We've got you covered:
+
+```sh
+npm install --save express-pino-logger
+```
+
+```js
+var app = require('express')()
+var pino = require('express-pino-logger')()
+
+app.use(pino)
+
+app.get('/', function (req, res) {
+  req.log.info('something')
+  res.send('hello world')
+})
+
+app.listen(3000)
+```
+
+See the [express-pino-logger readme](http://npm.im/express-pino-logger) for more info.
 
 <a name="rotate"></a>
 ## How do I rotate log files
@@ -535,6 +579,25 @@ parents and children will end up in log output.
 
 * first stable release
 
+<a name="team"></a>
+## The Team
+
+### Matteo Collina
+
+<https://github.com/mcollina>
+
+<https://www.npmjs.com/~matteo.collina>
+
+<https://twitter.com/matteocollina>
+
+
+### David Mark Clements
+
+<https://github.com/davidmarkclements>
+
+<https://www.npmjs.com/~davidmarkclements>
+
+<https://twitter.com/davidmarkclem>
 
 <a name="acknowledgements"></a>
 ## Acknowledgements

--- a/benchmarks/basic.js
+++ b/benchmarks/basic.js
@@ -8,6 +8,11 @@ var winston = require('winston')
 var fs = require('fs')
 var dest = fs.createWriteStream('/dev/null')
 var plog = pino(dest)
+delete require.cache[require.resolve('../')]
+var plogExtreme = require('../')({extreme: true}, dest)
+delete require.cache[require.resolve('../')]
+var plogInsanity = require('../')({insanity: true}, dest)
+
 var max = 10
 var blog = bunyan.createLogger({
   name: 'myapp',
@@ -47,6 +52,18 @@ var run = bench([
   function benchPino (cb) {
     for (var i = 0; i < max; i++) {
       plog.info('hello world')
+    }
+    setImmediate(cb)
+  },
+  function benchPinoExreme (cb) {
+    for (var i = 0; i < max; i++) {
+      plogExtreme.info('hello world')
+    }
+    setImmediate(cb)
+  },
+  function benchPinoInsanity (cb) {
+    for (var i = 0; i < max; i++) {
+      plogInsanity.info('hello world')
     }
     setImmediate(cb)
   }

--- a/benchmarks/basic.js
+++ b/benchmarks/basic.js
@@ -10,8 +10,6 @@ var dest = fs.createWriteStream('/dev/null')
 var plog = pino(dest)
 delete require.cache[require.resolve('../')]
 var plogExtreme = require('../')({extreme: true}, dest)
-delete require.cache[require.resolve('../')]
-var plogInsanity = require('../')({insanity: true}, dest)
 
 var max = 10
 var blog = bunyan.createLogger({
@@ -58,12 +56,6 @@ var run = bench([
   function benchPinoExreme (cb) {
     for (var i = 0; i < max; i++) {
       plogExtreme.info('hello world')
-    }
-    setImmediate(cb)
-  },
-  function benchPinoInsanity (cb) {
-    for (var i = 0; i < max; i++) {
-      plogInsanity.info('hello world')
     }
     setImmediate(cb)
   }

--- a/benchmarks/child.js
+++ b/benchmarks/child.js
@@ -25,7 +25,7 @@ require('bole').output({
 })
 
 var run = bench([
-  function benchBunyanObj (cb) {
+  function benchBunyanChild (cb) {
     for (var i = 0; i < max; i++) {
       blog.info({ hello: 'world' })
     }

--- a/benchmarks/child.js
+++ b/benchmarks/child.js
@@ -9,8 +9,6 @@ var dest = fs.createWriteStream('/dev/null')
 var plog = pino(dest).child({ a: 'property' })
 delete require.cache[require.resolve('../')]
 var plogExtreme = require('../')({extreme: true}, dest).child({ a: 'property' })
-delete require.cache[require.resolve('../')]
-var plogInsanity = require('../')({insanity: true}, dest).child({ a: 'property' })
 
 var max = 10
 var blog = bunyan.createLogger({
@@ -48,12 +46,6 @@ var run = bench([
   function benchPinoExtremeChild (cb) {
     for (var i = 0; i < max; i++) {
       plogExtreme.info({ hello: 'world' })
-    }
-    setImmediate(cb)
-  },
-  function benchPinoInsanityChild (cb) {
-    for (var i = 0; i < max; i++) {
-      plogInsanity.info({ hello: 'world' })
     }
     setImmediate(cb)
   }

--- a/benchmarks/child.js
+++ b/benchmarks/child.js
@@ -7,6 +7,11 @@ var bole = require('bole')('bench')('child')
 var fs = require('fs')
 var dest = fs.createWriteStream('/dev/null')
 var plog = pino(dest).child({ a: 'property' })
+delete require.cache[require.resolve('../')]
+var plogExtreme = require('../')({extreme: true}, dest).child({ a: 'property' })
+delete require.cache[require.resolve('../')]
+var plogInsanity = require('../')({insanity: true}, dest).child({ a: 'property' })
+
 var max = 10
 var blog = bunyan.createLogger({
   name: 'myapp',
@@ -28,15 +33,27 @@ var run = bench([
     }
     setImmediate(cb)
   },
+  function benchBoleChild (cb) {
+    for (var i = 0; i < max; i++) {
+      bole.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  },
   function benchPinoChild (cb) {
     for (var i = 0; i < max; i++) {
       plog.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
-  function benchBoleChild (cb) {
+  function benchPinoExtremeChild (cb) {
     for (var i = 0; i < max; i++) {
-      bole.info({ hello: 'world' })
+      plogExtreme.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  },
+  function benchPinoInsanityChild (cb) {
+    for (var i = 0; i < max; i++) {
+      plogInsanity.info({ hello: 'world' })
     }
     setImmediate(cb)
   }

--- a/benchmarks/childChild.js
+++ b/benchmarks/childChild.js
@@ -8,8 +8,6 @@ var dest = fs.createWriteStream('/dev/null')
 var plog = pino(dest).child({ a: 'property' }).child({sub: 'child'})
 delete require.cache[require.resolve('../')]
 var plogExtreme = require('../')({extreme: true}, dest).child({ a: 'property' }).child({sub: 'child'})
-delete require.cache[require.resolve('../')]
-var plogInsanity = require('../')({insanity: true}, dest).child({ a: 'property' }).child({sub: 'child'})
 
 var max = 10
 var blog = bunyan.createLogger({
@@ -36,12 +34,6 @@ var run = bench([
   function benchPinoExtremeChildChild (cb) {
     for (var i = 0; i < max; i++) {
       plogExtreme.info({ hello: 'world' })
-    }
-    setImmediate(cb)
-  },
-  function benchPinoInsanityChildChild (cb) {
-    for (var i = 0; i < max; i++) {
-      plogInsanity.info({ hello: 'world' })
     }
     setImmediate(cb)
   }

--- a/benchmarks/childChild.js
+++ b/benchmarks/childChild.js
@@ -6,6 +6,11 @@ var bunyan = require('bunyan')
 var fs = require('fs')
 var dest = fs.createWriteStream('/dev/null')
 var plog = pino(dest).child({ a: 'property' }).child({sub: 'child'})
+delete require.cache[require.resolve('../')]
+var plogExtreme = require('../')({extreme: true}, dest).child({ a: 'property' }).child({sub: 'child'})
+delete require.cache[require.resolve('../')]
+var plogInsanity = require('../')({insanity: true}, dest).child({ a: 'property' }).child({sub: 'child'})
+
 var max = 10
 var blog = bunyan.createLogger({
   name: 'myapp',
@@ -25,6 +30,18 @@ var run = bench([
   function benchPinoChildChild (cb) {
     for (var i = 0; i < max; i++) {
       plog.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  },
+  function benchPinoExtremeChildChild (cb) {
+    for (var i = 0; i < max; i++) {
+      plogExtreme.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  },
+  function benchPinoInsanityChildChild (cb) {
+    for (var i = 0; i < max; i++) {
+      plogInsanity.info({ hello: 'world' })
     }
     setImmediate(cb)
   }

--- a/benchmarks/childCreation.js
+++ b/benchmarks/childCreation.js
@@ -9,8 +9,6 @@ var dest = fs.createWriteStream('/dev/null')
 var plog = pino(dest)
 delete require.cache[require.resolve('../')]
 var plogExtreme = require('../')({extreme: true}, dest)
-delete require.cache[require.resolve('../')]
-var plogInsanity = require('../')({insanity: true}, dest)
 
 var max = 10
 var blog = bunyan.createLogger({
@@ -36,13 +34,6 @@ var run = bench([
   },
   function benchPinoExtremeCreation (cb) {
     var child = plogExtreme.child({ a: 'property' })
-    for (var i = 0; i < max; i++) {
-      child.info({ hello: 'world' })
-    }
-    setImmediate(cb)
-  },
-  function benchPinoInsanityCreation (cb) {
-    var child = plogInsanity.child({ a: 'property' })
     for (var i = 0; i < max; i++) {
       child.info({ hello: 'world' })
     }

--- a/benchmarks/childCreation.js
+++ b/benchmarks/childCreation.js
@@ -7,6 +7,11 @@ var bole = require('bole')('bench')
 var fs = require('fs')
 var dest = fs.createWriteStream('/dev/null')
 var plog = pino(dest)
+delete require.cache[require.resolve('../')]
+var plogExtreme = require('../')({extreme: true}, dest)
+delete require.cache[require.resolve('../')]
+var plogInsanity = require('../')({insanity: true}, dest)
+
 var max = 10
 var blog = bunyan.createLogger({
   name: 'myapp',
@@ -24,6 +29,20 @@ require('bole').output({
 var run = bench([
   function benchPinoCreation (cb) {
     var child = plog.child({ a: 'property' })
+    for (var i = 0; i < max; i++) {
+      child.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  },
+  function benchPinoExtremeCreation (cb) {
+    var child = plogExtreme.child({ a: 'property' })
+    for (var i = 0; i < max; i++) {
+      child.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  },
+  function benchPinoInsanityCreation (cb) {
+    var child = plogInsanity.child({ a: 'property' })
     for (var i = 0; i < max; i++) {
       child.info({ hello: 'world' })
     }

--- a/benchmarks/childCreation.js
+++ b/benchmarks/childCreation.js
@@ -25,20 +25,6 @@ require('bole').output({
 })
 
 var run = bench([
-  function benchPinoCreation (cb) {
-    var child = plog.child({ a: 'property' })
-    for (var i = 0; i < max; i++) {
-      child.info({ hello: 'world' })
-    }
-    setImmediate(cb)
-  },
-  function benchPinoExtremeCreation (cb) {
-    var child = plogExtreme.child({ a: 'property' })
-    for (var i = 0; i < max; i++) {
-      child.info({ hello: 'world' })
-    }
-    setImmediate(cb)
-  },
   function benchBunyanCreation (cb) {
     var child = blog.child({ a: 'property' })
     for (var i = 0; i < max; i++) {
@@ -48,6 +34,20 @@ var run = bench([
   },
   function benchBoleCreation (cb) {
     var child = bole('child')
+    for (var i = 0; i < max; i++) {
+      child.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  },
+  function benchPinoCreation (cb) {
+    var child = plog.child({ a: 'property' })
+    for (var i = 0; i < max; i++) {
+      child.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  },
+  function benchPinoExtremeCreation (cb) {
+    var child = plogExtreme.child({ a: 'property' })
     for (var i = 0; i < max; i++) {
       child.info({ hello: 'world' })
     }

--- a/benchmarks/multiArg.js
+++ b/benchmarks/multiArg.js
@@ -10,6 +10,10 @@ var dest = fs.createWriteStream('/dev/null')
 var plog = pino(dest)
 delete require.cache[require.resolve('../')]
 var plogExtreme = require('../')({extreme: true}, dest)
+delete require.cache[require.resolve('../')]
+var plogUnsafe = require('../')({safe: false}, dest)
+delete require.cache[require.resolve('../')]
+var plogUnsafeExtreme = require('../')({extreme: true, safe: false}, dest)
 
 var deep = require('../package.json')
 deep.deep = Object.assign({}, deep)
@@ -124,6 +128,18 @@ var run = bench([
     }
     setImmediate(cb)
   },
+  function benchPinoUnsafeInterpolateAll (cb) {
+    for (var i = 0; i < max; i++) {
+      plogUnsafe.info('hello %s %j %d', 'world', {obj: true}, 4)
+    }
+    setImmediate(cb)
+  },
+  function benchPinoUnsafeExtremeInterpolateAll (cb) {
+    for (var i = 0; i < max; i++) {
+      plogUnsafeExtreme.info('hello %s %j %d', 'world', {obj: true}, 4)
+    }
+    setImmediate(cb)
+  },
   function benchBunyanInterpolateExtra (cb) {
     for (var i = 0; i < max; i++) {
       blog.info('hello %s %j %d', 'world', {obj: true}, 4, {another: 'obj'})
@@ -148,9 +164,21 @@ var run = bench([
     }
     setImmediate(cb)
   },
+  function benchPinoUnsafeInterpolateExtra (cb) {
+    for (var i = 0; i < max; i++) {
+      plogUnsafe.info('hello %s %j %d', 'world', {obj: true}, 4, {another: 'obj'})
+    }
+    setImmediate(cb)
+  },
   function benchPinoExtremeInterpolateExtra (cb) {
     for (var i = 0; i < max; i++) {
       plogExtreme.info('hello %s %j %d', 'world', {obj: true}, 4, {another: 'obj'})
+    }
+    setImmediate(cb)
+  },
+  function benchPinoUnsafeExtremeInterpolateExtra (cb) {
+    for (var i = 0; i < max; i++) {
+      plogUnsafeExtreme.info('hello %s %j %d', 'world', {obj: true}, 4, {another: 'obj'})
     }
     setImmediate(cb)
   },
@@ -178,9 +206,21 @@ var run = bench([
     }
     setImmediate(cb)
   },
+  function benchPinoUnsafeInterpolateDeep (cb) {
+    for (var i = 0; i < max; i++) {
+      plogUnsafe.info('hello %j', deep)
+    }
+    setImmediate(cb)
+  },
   function benchPinoExtremeInterpolateDeep (cb) {
     for (var i = 0; i < max; i++) {
       plogExtreme.info('hello %j', deep)
+    }
+    setImmediate(cb)
+  },
+  function benchPinoUnsafeExtremeInterpolateDeep (cb) {
+    for (var i = 0; i < max; i++) {
+      plogUnsafeExtreme.info('hello %j', deep)
     }
     setImmediate(cb)
   }

--- a/benchmarks/multiArg.js
+++ b/benchmarks/multiArg.js
@@ -10,8 +10,6 @@ var dest = fs.createWriteStream('/dev/null')
 var plog = pino(dest)
 delete require.cache[require.resolve('../')]
 var plogExtreme = require('../')({extreme: true}, dest)
-delete require.cache[require.resolve('../')]
-var plogInsanity = require('../')({insanity: true}, dest)
 
 var deep = require('../package.json')
 deep.deep = Object.assign({}, deep)
@@ -66,12 +64,6 @@ var run = bench([
     }
     setImmediate(cb)
   },
-  function benchPinoInsanityMulti (cb) {
-    for (var i = 0; i < max; i++) {
-      plogInsanity.info('hello', 'world')
-    }
-    setImmediate(cb)
-  },
   function benchBunyanInterpolate (cb) {
     for (var i = 0; i < max; i++) {
       blog.info('hello %s', 'world')
@@ -99,12 +91,6 @@ var run = bench([
   function benchPinoExtremeInterpolate (cb) {
     for (var i = 0; i < max; i++) {
       plogExtreme.info('hello %s', 'world')
-    }
-    setImmediate(cb)
-  },
-  function benchPinoInsanityInterpolate (cb) {
-    for (var i = 0; i < max; i++) {
-      plogInsanity.info('hello %s', 'world')
     }
     setImmediate(cb)
   },
@@ -138,12 +124,6 @@ var run = bench([
     }
     setImmediate(cb)
   },
-  function benchPinoInsanityInterpolateAll (cb) {
-    for (var i = 0; i < max; i++) {
-      plogInsanity.info('hello %s %j %d', 'world', {obj: true}, 4)
-    }
-    setImmediate(cb)
-  },
   function benchBunyanInterpolateExtra (cb) {
     for (var i = 0; i < max; i++) {
       blog.info('hello %s %j %d', 'world', {obj: true}, 4, {another: 'obj'})
@@ -174,12 +154,6 @@ var run = bench([
     }
     setImmediate(cb)
   },
-  function benchPinoInsanityInterpolateExtra (cb) {
-    for (var i = 0; i < max; i++) {
-      plogInsanity.info('hello %s %j %d', 'world', {obj: true}, 4, {another: 'obj'})
-    }
-    setImmediate(cb)
-  },
   function benchBunyanInterpolateDeep (cb) {
     for (var i = 0; i < max; i++) {
       blog.info('hello %j', deep)
@@ -207,12 +181,6 @@ var run = bench([
   function benchPinoExtremeInterpolateDeep (cb) {
     for (var i = 0; i < max; i++) {
       plogExtreme.info('hello %j', deep)
-    }
-    setImmediate(cb)
-  },
-  function benchPinoInsanityInterpolateDeep (cb) {
-    for (var i = 0; i < max; i++) {
-      plogInsanity.info('hello %j', deep)
     }
     setImmediate(cb)
   }

--- a/benchmarks/multiArg.js
+++ b/benchmarks/multiArg.js
@@ -8,6 +8,11 @@ var winston = require('winston')
 var fs = require('fs')
 var dest = fs.createWriteStream('/dev/null')
 var plog = pino(dest)
+delete require.cache[require.resolve('../')]
+var plogExtreme = require('../')({extreme: true}, dest)
+delete require.cache[require.resolve('../')]
+var plogInsanity = require('../')({insanity: true}, dest)
+
 var deep = require('../package.json')
 deep.deep = Object.assign({}, deep)
 deep.deep.deep = Object.assign({}, deep)
@@ -55,6 +60,18 @@ var run = bench([
     }
     setImmediate(cb)
   },
+  function benchPinoExtremeMulti (cb) {
+    for (var i = 0; i < max; i++) {
+      plogExtreme.info('hello', 'world')
+    }
+    setImmediate(cb)
+  },
+  function benchPinoInsanityMulti (cb) {
+    for (var i = 0; i < max; i++) {
+      plogInsanity.info('hello', 'world')
+    }
+    setImmediate(cb)
+  },
   function benchBunyanInterpolate (cb) {
     for (var i = 0; i < max; i++) {
       blog.info('hello %s', 'world')
@@ -76,6 +93,18 @@ var run = bench([
   function benchPinoInterpolate (cb) {
     for (var i = 0; i < max; i++) {
       plog.info('hello %s', 'world')
+    }
+    setImmediate(cb)
+  },
+  function benchPinoExtremeInterpolate (cb) {
+    for (var i = 0; i < max; i++) {
+      plogExtreme.info('hello %s', 'world')
+    }
+    setImmediate(cb)
+  },
+  function benchPinoInsanityInterpolate (cb) {
+    for (var i = 0; i < max; i++) {
+      plogInsanity.info('hello %s', 'world')
     }
     setImmediate(cb)
   },
@@ -103,6 +132,18 @@ var run = bench([
     }
     setImmediate(cb)
   },
+  function benchPinoExtremeInterpolateAll (cb) {
+    for (var i = 0; i < max; i++) {
+      plogExtreme.info('hello %s %j %d', 'world', {obj: true}, 4)
+    }
+    setImmediate(cb)
+  },
+  function benchPinoInsanityInterpolateAll (cb) {
+    for (var i = 0; i < max; i++) {
+      plogInsanity.info('hello %s %j %d', 'world', {obj: true}, 4)
+    }
+    setImmediate(cb)
+  },
   function benchBunyanInterpolateExtra (cb) {
     for (var i = 0; i < max; i++) {
       blog.info('hello %s %j %d', 'world', {obj: true}, 4, {another: 'obj'})
@@ -127,6 +168,18 @@ var run = bench([
     }
     setImmediate(cb)
   },
+  function benchPinoExtremeInterpolateExtra (cb) {
+    for (var i = 0; i < max; i++) {
+      plogExtreme.info('hello %s %j %d', 'world', {obj: true}, 4, {another: 'obj'})
+    }
+    setImmediate(cb)
+  },
+  function benchPinoInsanityInterpolateExtra (cb) {
+    for (var i = 0; i < max; i++) {
+      plogInsanity.info('hello %s %j %d', 'world', {obj: true}, 4, {another: 'obj'})
+    }
+    setImmediate(cb)
+  },
   function benchBunyanInterpolateDeep (cb) {
     for (var i = 0; i < max; i++) {
       blog.info('hello %j', deep)
@@ -148,6 +201,18 @@ var run = bench([
   function benchPinoInterpolateDeep (cb) {
     for (var i = 0; i < max; i++) {
       plog.info('hello %j', deep)
+    }
+    setImmediate(cb)
+  },
+  function benchPinoExtremeInterpolateDeep (cb) {
+    for (var i = 0; i < max; i++) {
+      plogExtreme.info('hello %j', deep)
+    }
+    setImmediate(cb)
+  },
+  function benchPinoInsanityInterpolateDeep (cb) {
+    for (var i = 0; i < max; i++) {
+      plogInsanity.info('hello %j', deep)
     }
     setImmediate(cb)
   }

--- a/benchmarks/object.js
+++ b/benchmarks/object.js
@@ -10,6 +10,10 @@ var dest = fs.createWriteStream('/dev/null')
 var plog = pino(dest)
 delete require.cache[require.resolve('../')]
 var plogExtreme = require('../')({extreme: true}, dest)
+delete require.cache[require.resolve('../')]
+var plogUnsafe = require('../')({safe: false}, dest)
+delete require.cache[require.resolve('../')]
+var plogUnsafeExtreme = require('../')({extreme: true, safe: false}, dest)
 
 var max = 10
 var blog = bunyan.createLogger({
@@ -53,9 +57,21 @@ var run = bench([
     }
     setImmediate(cb)
   },
+  function benchPinoUnsafeObj (cb) {
+    for (var i = 0; i < max; i++) {
+      plogUnsafe.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  },
   function benchPinoExtremeObj (cb) {
     for (var i = 0; i < max; i++) {
       plogExtreme.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  },
+  function benchPinoUnsafeExtremeObj (cb) {
+    for (var i = 0; i < max; i++) {
+      plogUnsafeExtreme.info({ hello: 'world' })
     }
     setImmediate(cb)
   }

--- a/benchmarks/object.js
+++ b/benchmarks/object.js
@@ -8,6 +8,11 @@ var winston = require('winston')
 var fs = require('fs')
 var dest = fs.createWriteStream('/dev/null')
 var plog = pino(dest)
+delete require.cache[require.resolve('../')]
+var plogExtreme = require('../')({extreme: true}, dest)
+delete require.cache[require.resolve('../')]
+var plogInsanity = require('../')({insanity: true}, dest)
+
 var max = 10
 var blog = bunyan.createLogger({
   name: 'myapp',
@@ -47,6 +52,18 @@ var run = bench([
   function benchPinoObj (cb) {
     for (var i = 0; i < max; i++) {
       plog.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  },
+  function benchPinoExtremeObj (cb) {
+    for (var i = 0; i < max; i++) {
+      plogExtreme.info({ hello: 'world' })
+    }
+    setImmediate(cb)
+  },
+  function benchPinoInsanityObj (cb) {
+    for (var i = 0; i < max; i++) {
+      plogInsanity.info({ hello: 'world' })
     }
     setImmediate(cb)
   }

--- a/benchmarks/object.js
+++ b/benchmarks/object.js
@@ -10,8 +10,6 @@ var dest = fs.createWriteStream('/dev/null')
 var plog = pino(dest)
 delete require.cache[require.resolve('../')]
 var plogExtreme = require('../')({extreme: true}, dest)
-delete require.cache[require.resolve('../')]
-var plogInsanity = require('../')({insanity: true}, dest)
 
 var max = 10
 var blog = bunyan.createLogger({
@@ -58,12 +56,6 @@ var run = bench([
   function benchPinoExtremeObj (cb) {
     for (var i = 0; i < max; i++) {
       plogExtreme.info({ hello: 'world' })
-    }
-    setImmediate(cb)
-  },
-  function benchPinoInsanityObj (cb) {
-    for (var i = 0; i < max; i++) {
-      plogInsanity.info({ hello: 'world' })
     }
     setImmediate(cb)
   }

--- a/flatten-string.js
+++ b/flatten-string.js
@@ -1,0 +1,3 @@
+module.exports = function (s) {
+  return %FlattenString(s)
+}

--- a/flatten-string.js
+++ b/flatten-string.js
@@ -1,3 +1,0 @@
-module.exports = function (s) {
-  return %FlattenString(s)
-}

--- a/package.json
+++ b/package.json
@@ -14,11 +14,6 @@
     "type": "git",
     "url": "git+https://github.com/mcollina/pino.git"
   },
-  "standard": {
-    "ignore": [
-      "flatten-string.js"
-    ]
-  },
   "keywords": [
     "fast",
     "logger",
@@ -46,6 +41,7 @@
     "core-util-is": "^1.0.2",
     "fast-json-parse": "^1.0.0",
     "fast-safe-stringify": "^1.0.4",
+    "flatstr": "^1.0.0",
     "quick-format": "^2.0.0",
     "split2": "^2.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "type": "git",
     "url": "git+https://github.com/mcollina/pino.git"
   },
+  "standard": {
+    "ignore": [
+      "flatten-string.js"
+    ]
+  },
   "keywords": [
     "fast",
     "logger",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "winston": "^2.1.1"
   },
   "dependencies": {
+    "before-death": "^0.9.1",
     "chalk": "^1.1.1",
     "core-util-is": "^1.0.2",
     "fast-json-parse": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     "winston": "^2.1.1"
   },
   "dependencies": {
-    "before-death": "^0.9.1",
     "chalk": "^1.1.1",
     "core-util-is": "^1.0.2",
     "fast-json-parse": "^1.0.0",
     "fast-safe-stringify": "^1.0.4",
     "flatstr": "^1.0.0",
+    "once": "^1.3.3",
     "quick-format": "^2.0.0",
     "split2": "^2.0.1"
   }

--- a/pino.js
+++ b/pino.js
@@ -4,7 +4,7 @@ var stringifySafe = require('fast-safe-stringify')
 var format = require('quick-format')
 var os = require('os')
 var flatstr = require('flatstr')
-var onExit = require('before-death')
+var once = require('once')
 var pid = process.pid
 var hostname = os.hostname()
 
@@ -238,6 +238,17 @@ function genLog (z) {
     }
     this.write(m, o, z)
   }
+}
+
+function onExit (fn) {
+  fn = once(fn)
+  process.on('beforeExit', fn)
+  process.on('exit', fn)
+  process.on('uncaughtException', fn)
+  process.on('SIGHUP', fn)
+  process.on('SIGINT', fn)
+  process.on('SIGQUIT', fn)
+  process.on('SIGTERM', fn)
 }
 
 module.exports = pino

--- a/pino.js
+++ b/pino.js
@@ -50,7 +50,6 @@ function pino (opts, stream) {
       } else {
         stream.write(logger.buf)
       }
-      process.exit()
     })
   }
 

--- a/pino.js
+++ b/pino.js
@@ -33,13 +33,14 @@ function pino (opts, stream) {
   var slowtime = opts.slowtime
   var safe = opts.safe !== false
   var stringify = safe ? stringifySafe : JSON.stringify
+  var formatOpts = safe ? null : {lowres: true}
   var name = opts.name
   var level = opts.level || 'info'
   var serializers = opts.serializers || {}
   var end = ',"v":' + LOG_VERSION + '}\n'
   var cache = opts.extreme ? 4096 : 0
 
-  var logger = new Pino(level, stream, serializers, stringify, end, name, hostname, slowtime, '', cache)
+  var logger = new Pino(level, stream, serializers, stringify, end, name, hostname, slowtime, '', cache, formatOpts)
 
   if (cache) {
     onExit(function (code, evt) {
@@ -64,7 +65,7 @@ function pino (opts, stream) {
   return logger
 }
 
-function Pino (level, stream, serializers, stringify, end, name, hostname, slowtime, chindings, cache) {
+function Pino (level, stream, serializers, stringify, end, name, hostname, slowtime, chindings, cache, formatOpts) {
   this.stream = stream
   this.serializers = serializers
   this.stringify = stringify
@@ -75,6 +76,7 @@ function Pino (level, stream, serializers, stringify, end, name, hostname, slowt
   this.chindings = chindings
   this.buf = ''
   this.cache = cache
+  this.formatOpts = formatOpts
   this._setLevel(level)
 }
 
@@ -161,7 +163,7 @@ Pino.prototype.child = function child (bindings) {
   }
   data = this.chindings + data.substr(0, data.length - 1)
 
-  return new Pino(this.level, this.stream, this.serializers, this.stringify, this.end, this.name, this.hostname, this.slowtime, data, this.cache)
+  return new Pino(this.level, this.stream, this.serializers, this.stringify, this.end, this.name, this.hostname, this.slowtime, data, this.cache, this.formatOpts)
 }
 
 Pino.prototype.write = function (obj, msg, num) {
@@ -239,7 +241,7 @@ function genLog (z) {
     }
     p = n.length = arguments.length - l
     if (p > 1) {
-      o = format(n, null)
+      o = format(n, this.formatOpts)
     } else if (p) {
       o = n[0]
     }

--- a/pino.js
+++ b/pino.js
@@ -151,7 +151,7 @@ Pino.prototype.child = function child (bindings) {
   }
   data = this.chindings + data.substr(0, data.length - 1)
 
-  return new Pino(this.level, this.stream, this.serializers, this.stringify, this.end, this.name, this.hostname, this.slowtime, data)
+  return new Pino(this.level, this.stream, this.serializers, this.stringify, this.end, this.name, this.hostname, this.slowtime, data, this.cache, this.flatstr)
 }
 
 Pino.prototype.write = function (obj, msg, num) {

--- a/test.js
+++ b/test.js
@@ -525,10 +525,20 @@ test('throw if creating child without bindings', function (t) {
 
 test('extreme mode', function (t) {
   var now = Date.now
+  var hostname = os.hostname
+  var proc = process
+  global.process = {
+    __proto__: process,
+    pid: 123456
+  }
   Date.now = function () {
     return 1459875739796
   }
-
+  os.hostname = function () {
+    return 'abcdefghijklmnopqr'
+  }
+  delete require.cache[require.resolve('./')]
+  var pino = require('./')
   var expected = ''
   var actual = ''
   var normal = pino(writeStream(function (s, enc, cb) {
@@ -548,7 +558,8 @@ test('extreme mode', function (t) {
   }
 
   t.is(actual, expected)
-
+  os.hostname = hostname
   Date.now = now
+  global.process = proc
   t.end()
 })

--- a/test.js
+++ b/test.js
@@ -522,3 +522,33 @@ test('throw if creating child without bindings', function (t) {
     instance.child()
   })
 })
+
+test('extreme mode', function (t) {
+  var now = Date.now
+  Date.now = function () {
+    return 1459875739796
+  }
+
+  var expected = ''
+  var actual = ''
+  var normal = pino(writeStream(function (s, enc, cb) {
+    expected += s
+    cb()
+  }))
+
+  var extreme = pino({extreme: true}, writeStream(function (s, enc, cb) {
+    actual += s
+    cb()
+  }))
+
+  var i = 44
+  while (i--) {
+    normal.info('h')
+    extreme.info('h')
+  }
+
+  t.is(actual, expected)
+
+  Date.now = now
+  t.end()
+})

--- a/test.js
+++ b/test.js
@@ -573,9 +573,11 @@ test('extreme mode', function (t) {
     t.is(actual, expected)
     t.is(actual2.trim(), expected2)
 
-    os.hostname = hostname
-    Date.now = now
-    global.process = proc
+    t.teardown(function () {
+      os.hostname = hostname
+      Date.now = now
+      global.process = proc
+    })
 
     t.end()
   })


### PR DESCRIPTION
Ok so this one breaks all the tests, but it still actually functionally equivalent.

Here's the idea - caching log strings up to 2MB, then writing to log (this is why
the tests fail because it's no longer exact input/output). When the process exits
we write whatevers left in the cache (not sure if this is problematic, seems to work, 
maybe wouldn't work if the cache was larger). 

We should probably use the `death` module or some equivalent to make sure we catch all exit scenarios, but just wanted to throw this out there for discussion. 

Here's new benchmarks:

basic:
```
benchBunyan*10000: 1134.796ms
benchWinston*10000: 1828.768ms
benchBole*10000: 1595.314ms
benchPino*10000: 151.062ms
benchBunyan*10000: 1109.045ms
benchWinston*10000: 1877.307ms
benchBole*10000: 1620.304ms
benchPino*10000: 148.871ms
```

object:

```
benchBunyanObj*10000: 1275.334ms
benchWinstonObj*10000: 1913.518ms
benchBoleObj*10000: 1539.534ms
benchPinoObj*10000: 188.245ms
benchBunyanObj*10000: 1251.408ms
benchWinstonObj*10000: 1847.023ms
benchBoleObj*10000: 1555.642ms
benchPinoObj*10000: 184.770ms
```


