### PR TITLE
60% perf improvement on large objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ benchPinoObj*10000: 322.118ms
 benchPinoExtremeObj*10000: 142.215ms
 ```
 
+`pino.info(aBigDeeplyNestedObject)`:
+```
+benchBunyanDeepObj*10000: 6148.665ms
+benchWinstonDeepObj*10000: 14726.129ms
+benchBoleDeepObj*10000: 24450.814ms
+benchPinoDeepObj*10000: 4296.618ms
+benchPinoUnsafeDeepObj*10000: 3065.568ms
+benchPinoExtremeDeepObj*10000: 4139.848ms
+benchPinoUnsafeExtremeDeepObj*10000: 2948.078ms
+```
+
 `pino.info('hello %s %j %d', 'world', {obj: true}, 4, {another: 'obj'})`:
 
 ```

--- a/benchmarks/deep-object.js
+++ b/benchmarks/deep-object.js
@@ -1,0 +1,85 @@
+'use strict'
+
+var bench = require('fastbench')
+var pino = require('../')
+var bunyan = require('bunyan')
+var bole = require('bole')('bench')
+var winston = require('winston')
+var fs = require('fs')
+var dest = fs.createWriteStream('/dev/null')
+var plog = pino(dest)
+delete require.cache[require.resolve('../')]
+var plogExtreme = require('../')({extreme: true}, dest)
+delete require.cache[require.resolve('../')]
+var plogUnsafe = require('../')({safe: false}, dest)
+delete require.cache[require.resolve('../')]
+var plogUnsafeExtreme = require('../')({extreme: true, safe: false}, dest)
+
+var deep = require('../package.json')
+deep.deep = Object.assign({}, deep)
+deep.deep.deep = Object.assign({}, deep.deep)
+deep.deep.deep.deep = Object.assign({}, deep.deep.deep)
+
+var max = 10
+var blog = bunyan.createLogger({
+  name: 'myapp',
+  streams: [{
+    level: 'trace',
+    stream: dest
+  }]
+})
+
+require('bole').output({
+  level: 'info',
+  stream: dest
+})
+
+winston.add(winston.transports.File, { filename: '/dev/null' })
+winston.remove(winston.transports.Console)
+
+var run = bench([
+  function benchBunyanDeepObj (cb) {
+    for (var i = 0; i < max; i++) {
+      blog.info(deep)
+    }
+    setImmediate(cb)
+  },
+  function benchWinstonDeepObj (cb) {
+    for (var i = 0; i < max; i++) {
+      winston.info(deep)
+    }
+    setImmediate(cb)
+  },
+  function benchBoleDeepObj (cb) {
+    for (var i = 0; i < max; i++) {
+      bole.info(deep)
+    }
+    setImmediate(cb)
+  },
+  function benchPinoDeepObj (cb) {
+    for (var i = 0; i < max; i++) {
+      plog.info(deep)
+    }
+    setImmediate(cb)
+  },
+  function benchPinoUnsafeDeepObj (cb) {
+    for (var i = 0; i < max; i++) {
+      plogUnsafe.info(deep)
+    }
+    setImmediate(cb)
+  },
+  function benchPinoExtremeDeepObj (cb) {
+    for (var i = 0; i < max; i++) {
+      plogExtreme.info(deep)
+    }
+    setImmediate(cb)
+  },
+  function benchPinoUnsafeExtremeDeepObj (cb) {
+    for (var i = 0; i < max; i++) {
+      plogUnsafeExtreme.info(deep)
+    }
+    setImmediate(cb)
+  }
+], 10000)
+
+run(run)

--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     "chalk": "^1.1.1",
     "core-util-is": "^1.0.2",
     "fast-json-parse": "^1.0.0",
-    "fast-safe-stringify": "^1.0.4",
+    "fast-safe-stringify": "^1.0.8",
     "flatstr": "^1.0.0",
     "once": "^1.3.3",
-    "quick-format": "^2.0.0",
+    "quick-format": "^2.0.3",
     "split2": "^2.0.1"
   }
 }


### PR DESCRIPTION
closes #14 

the work here is really in fast-safe-stringify 2.0.8 (commit here: https://github.com/davidmarkclements/fast-safe-stringify/commit/12e285de5050c81f64c64d2daeca1879c80fb4ca)

api and output have stayed the same, so it's a patch bump, which means any new installs of pino benefit immediately. 

* in normal mode, faster the all other benched loggers at logging a deep object
* in normal mode, faster than all benched loggers at deep object interpolation, except bunyan, of which we're ~8% shy
* general speed ups for all object logging scenarios

log deep object: 
```
benchBunyanDeepObj*10000: 6148.665ms
benchWinstonDeepObj*10000: 14726.129ms
benchBoleDeepObj*10000: 24450.814ms
benchPinoDeepObj*10000: 4296.618ms
benchPinoUnsafeDeepObj*10000: 3065.568ms
benchPinoExtremeDeepObj*10000: 4139.848ms
benchPinoUnsafeExtremeDeepObj*10000: 2948.078ms
```

interpolate deep object:
```
benchBunyanInterpolateDeep*10000: 4231.207ms
benchWinstonInterpolateDeep*10000: 16486.350ms
benchBoleInterpolateDeep*10000: 5071.670ms
benchPinoInterpolateDeep*10000: 4803.197ms
benchPinoUnsafeInterpolateDeep*10000: 3482.401ms
benchPinoExtremeInterpolateDeep*10000: 4862.077ms
benchPinoUnsafeExtremeInterpolateDeep*10000: 3334.657ms
```

How fast-safe-stringify is now the fastest safe serializer around:

In the end, the way fast-safe-stringify was made faster was to iterate over the object before stringifying (instead of passing a replacer function to JSON.stringify), and actually *replace* circular references in the object (instead of cloning). Obviously this led to the issue of modifying the object being passed. Iterating over the object *again* to put all the displaced references back together proved too expensive. So the trick to it was to use the toJSON property of circular replacements to reapply the reference to the object during stringification, like so:

```js
function Circle(val, k, parent) {
  this.val = val
  this.k = k
  this.parent = parent
 }
Circle.prototype.toJSON = function toJSON() { 
  this.parent[this.k] = this.val; 
  return '[Circular]' 
}
```

So whenever a circular ref is identified we replace it with a Circle object, once the `JSON.stringify` function hits a circle object, it notices the toJSON method, and calls it.  The Circle object then overwrites itself with the original reference. All tests are passing, all output is exactly the same as previous version. 