### PR TITLE
Add JSON to keywords to improve discoverability

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "keywords": [
     "fast",
     "logger",
-    "stream"
+    "stream",
+    "json"
   ],
   "author": "Matteo Collina <hello@matteocollina.com>",
   "license": "MIT",


### PR DESCRIPTION
I came across with `pino` by accident. I couldn't find pino when searching for `log json`.