### PR TITLE
Fixed CLI interface

### DIFF
--- a/pretty.js
+++ b/pretty.js
@@ -115,7 +115,7 @@ function pretty (opts) {
 module.exports = pretty
 
 if (require.main === module) {
-  if (process.argv.length < 3 || arg('-h') || arg('--help')) {
+  if (arg('-h') || arg('--help')) {
     usage().pipe(process.stdout)
   } else if (arg('-v') || arg('--version')) {
     console.log(require('./package.json').version)


### PR DESCRIPTION
CLI always showed usage information when run without any command line arguments.

According to the documentation it should launch the prettifier:
```
cat log | pino
```

This bug was introduced in v2.2.2.