### PR TITLE
trailing comma and --mute

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ Into this:
 {"pid":14139,"hostname":"MacBook-Pro-3.home","level":30,"msg":"hello world","time":"2016-03-09T15:27:09.339Z","v":0}
 ```
 
+Can skip logs with `--mute` option:
+
+```sh
+cat log | pino --mute
+```
+
 <a name="api"></a>
 ## API
 
@@ -384,7 +390,7 @@ pino.levels.labels[50] === 'error' // true
 <a name="log_version"></a>
 ### logger.LOG_VERSION & pino.LOG_VERSION
 
-Read only. Holds the current log format version (as output in the `v` property of each log record). 
+Read only. Holds the current log format version (as output in the `v` property of each log record).
 
 
 <a name="reqSerializer"></a>

--- a/pretty.js
+++ b/pretty.js
@@ -81,7 +81,7 @@ function pretty (opts) {
 
     if (parsed.err) {
       // pass through
-      return line + '/n'
+      return line
     }
 
     if (mute) {

--- a/pretty.js
+++ b/pretty.js
@@ -48,6 +48,7 @@ function filter (value) {
 
 function pretty (opts) {
   var timeTransOnly = opts && opts.timeTransOnly
+  var mute = opts && opts.mute
 
   var stream = split(mapLine)
   var ctx
@@ -80,7 +81,11 @@ function pretty (opts) {
 
     if (parsed.err) {
       // pass through
-      return line
+      return line + '/n'
+    }
+
+    if (mute) {
+      return ''
     }
 
     if (timeTransOnly) {
@@ -121,7 +126,8 @@ if (require.main === module) {
     console.log(require('./package.json').version)
   } else {
     process.stdin.pipe(pretty({
-      timeTransOnly: arg('-t')
+      timeTransOnly: arg('-t'),
+      mute: arg('--mute')
     })).pipe(process.stdout)
   }
 }

--- a/usage.txt
+++ b/usage.txt
@@ -1,4 +1,4 @@
-  
+
   [0m[37m[1m[4mPino[22m[39m[0m
 
   [0mTo prettify logs, simply pipe a log file through [33mpino[39m:[0m
@@ -13,4 +13,4 @@
   [0m-h | --help      Display Help
   -v | --version   Display Version
   -t               Convert Epoch timestamps to ISO[0m
-
+  --mute           Skip logs


### PR DESCRIPTION
Used with [mocha](https://mochajs.org/).

### Trailing comma 

to avoid this:
```
    ✓ should raise error if file does not exist[2016-05-11T09:03:34.958Z] INFO (app/: Send the file
```
and instead have this:
```
    ✓ should raise error if file does not exist
[2016-05-11T09:03:34.958Z] INFO (app/: Send the file
```

### CLI option `--mute`
to have test results without logs