### PR TITLE
instance.child() should set the level property in pino

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ the current log level of the parent at the time they are spawned.
 
 From v2.x.x the log level of a child is mutable (whereas in
 v1.x.x it was immutable), and can be set independently of the parent.
+You can pass `level` as a property inside the `bindings`, and that will
+be set.
 
 For example
 
@@ -242,6 +244,7 @@ child.info('nope again') //does not log
 child.level = 'info'
 child.info('hooray') //will log
 logger.info('nope nope nope') //will not log, level is still set to error
+logger.child({ foo: 'bar', level: 'debug' }).debug('debug!')
 ```
 
 Also from version 2.x.x we can spawn child loggers from child loggers, for instance

--- a/README.md
+++ b/README.md
@@ -230,8 +230,8 @@ the current log level of the parent at the time they are spawned.
 
 From v2.x.x the log level of a child is mutable (whereas in
 v1.x.x it was immutable), and can be set independently of the parent.
-You can pass `level` as a property inside the `bindings`, and that will
-be set.
+If a `level` property is present in the object passed to `child` it will
+override the child logger level.
 
 For example
 

--- a/pino.js
+++ b/pino.js
@@ -211,14 +211,25 @@ Pino.prototype.child = function child (bindings) {
   var key
   for (key in bindings) {
     value = bindings[key]
-    if (bindings.hasOwnProperty(key) && value !== undefined) {
+    if (key !== 'level' && bindings.hasOwnProperty(key) && value !== undefined) {
       value = this.serializers[key] ? this.serializers[key](value) : value
       data += '"' + key + '":' + this.stringify(value) + ','
     }
   }
   data = this.chindings + data.substr(0, data.length - 1)
 
-  return new Pino(this.level, this.stream, this.serializers, this.stringify, this.end, this.name, this.hostname, this.slowtime, data, this.cache, this.formatOpts)
+  return new Pino(
+    bindings.level || this.level,
+    this.stream,
+    this.serializers,
+    this.stringify,
+    this.end,
+    this.name,
+    this.hostname,
+    this.slowtime,
+    data,
+    this.cache,
+    this.formatOpts)
 }
 
 Pino.prototype.write = function (obj, msg, num) {

--- a/test/levels.test.js
+++ b/test/levels.test.js
@@ -175,6 +175,27 @@ test('exposed labels', function (t) {
   ])
 })
 
+test('setting level in child', function (t) {
+  t.plan(4)
+  var expected = [{
+    level: 50,
+    msg: 'this is an error'
+  }, {
+    level: 60,
+    msg: 'this is fatal'
+  }]
+  var instance = pino(sink(function (chunk, enc, cb) {
+    var current = expected.shift()
+    check(t, chunk, current.level, current.msg)
+    cb()
+  })).child({ level: 30 })
+
+  instance.level = 'error'
+  instance.info('hello world')
+  instance.error('this is an error')
+  instance.fatal('this is fatal')
+})
+
 test('level-change event', function (t) {
   var instance = pino()
   var handle = function (lvl, val, prevLvl, prevVal) {


### PR DESCRIPTION
Fixes #55.

@davidmarkclements please review.

Benchmarks stays the same.