### PR TITLE
allow serializers to strip keys

### DIFF
--- a/pino.js
+++ b/pino.js
@@ -222,7 +222,9 @@ Pino.prototype.asJson = function asJson (obj, msg, num) {
         value = obj[key]
         if (obj.hasOwnProperty(key) && value !== undefined) {
           value = this.serializers[key] ? this.serializers[key](value) : value
-          data += ',"' + key + '":' + this.stringify(value)
+          if (value !== undefined) {
+            data += ',"' + key + '":' + this.stringify(value)
+          }
         }
       }
     }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -147,6 +147,20 @@ levelTest('info', 30)
 levelTest('debug', 20)
 levelTest('trace', 10)
 
+test('serializers can return undefined to strip field', function (t) {
+  t.plan(1)
+  var instance = pino({
+    serializers: {
+      test: function (o) { return undefined }
+    }
+  }, sink(function (obj, enc, cb) {
+    t.notOk('test' in obj)
+    cb()
+  }))
+
+  instance.info({ test: 'sensitive info' })
+})
+
 test('does not explode with a circular ref', function (t) {
   var instance = pino(sink(function (chunk, enc, cb) {
     // nothing to check


### PR DESCRIPTION
If a serializer returns undefined, the key/value shouldn't be added to the JSON

This will allow a serlializer to strip both a key and a value (by returning undefined)

Also, if an object has an undefined value, it gets excluded from stringification, so we should follow the same behaviour

cc @mcollina @emilyrose