### PR TITLE
Add level first flag to pretty options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,13 +149,20 @@ Then we simply pipe a log file through `pino`:
 cat log | pino
 ```
 
-There's also a transformer flag that converts Epoch timestamps to ISO timestamps.
+There are also two transformer flags.. 
+
+ `-t` that converts Epoch timestamps to ISO timestamps.
 
 ```sh
 cat log | pino -t
 ```
+ and `-l` that flips the time and level on the standard output.
 
-For instance, `pino -t` will transform this:
+```sh
+cat log | pino -l
+```
+
+`pino -t` will transform this:
 
 ```js
 {"pid":14139,"hostname":"MacBook-Pro-3.home","level":30,"msg":"hello world","time":1457537229339,"v":0}
@@ -165,6 +172,19 @@ Into this:
 
 ```js
 {"pid":14139,"hostname":"MacBook-Pro-3.home","level":30,"msg":"hello world","time":"2016-03-09T15:27:09.339Z","v":0}
+```
+
+ 
+`pino -l` will transform this:
+
+```sh
+[2016-03-09T15:27:09.339Z] INFO (14139 on MacBook-Pro-3.home): hello world
+```
+
+Into this:
+
+```sh
+INFO [2016-03-09T15:27:09.339Z] (14139 on MacBook-Pro-3.home): hello world
 ```
 
 <a name="api"></a>

--- a/pretty.js
+++ b/pretty.js
@@ -48,6 +48,7 @@ function filter (value) {
 
 function pretty (opts) {
   var timeTransOnly = opts && opts.timeTransOnly
+  var levelFirst = opts && opts.levelFirst
 
   var stream = split(mapLine)
   var ctx
@@ -88,7 +89,10 @@ function pretty (opts) {
       return JSON.stringify(value) + '\n'
     }
 
-    line = '[' + new Date(value.time).toISOString() + '] ' + asColoredLevel(value)
+    line = (levelFirst)
+        ? asColoredLevel(value) + ' [' + new Date(value.time).toISOString() + ']'
+        : '[' + new Date(value.time).toISOString() + '] ' + asColoredLevel(value)
+
     line += ' ('
     if (value.name) {
       line += value.name + '/'

--- a/pretty.js
+++ b/pretty.js
@@ -85,13 +85,13 @@ function pretty (opts) {
     }
 
     if (timeTransOnly) {
-      value.time = new Date(value.time).toISOString()
+      value.time = asISODate(value.time)
       return JSON.stringify(value) + '\n'
     }
 
     line = (levelFirst)
-        ? asColoredLevel(value) + ' [' + new Date(value.time).toISOString() + ']'
-        : '[' + new Date(value.time).toISOString() + '] ' + asColoredLevel(value)
+        ? asColoredLevel(value) + ' [' + asISODate(value.time) + ']'
+        : '[' + asISODate(value.time) + '] ' + asColoredLevel(value)
 
     line += ' ('
     if (value.name) {
@@ -109,6 +109,10 @@ function pretty (opts) {
       line += filter(value)
     }
     return line
+  }
+
+  function asISODate (time) {
+    return new Date(time).toISOString()
   }
 
   function asColoredLevel (value) {

--- a/pretty.js
+++ b/pretty.js
@@ -125,7 +125,8 @@ if (require.main === module) {
     console.log(require('./package.json').version)
   } else {
     process.stdin.pipe(pretty({
-      timeTransOnly: arg('-t')
+      timeTransOnly: arg('-t'),
+      levelFirst: arg('-l')
     })).pipe(process.stdout)
   }
 }

--- a/test/pretty.test.js
+++ b/test/pretty.test.js
@@ -11,7 +11,22 @@ test('pino transform prettifies', function (t) {
   var pretty = pino.pretty()
   pretty.pipe(split(function (line) {
     t.ok(line.match(/.*hello world$/), 'end of line matches')
-    t.ok(line.match(/.*INFO.*/), 'includes level')
+    t.ok(line.match(/(?!^)INFO.*/), 'includes level')
+    t.ok(line.indexOf('' + process.pid) > 0, 'includes pid')
+    t.ok(line.indexOf('' + hostname) > 0, 'includes hostname')
+    return line
+  }))
+  var instance = pino(pretty)
+
+  instance.info('hello world')
+})
+
+test('pino pretty moves level to start on flag', function (t) {
+  t.plan(4)
+  var pretty = pino.pretty({ levelFirst: true })
+  pretty.pipe(split(function (line) {
+    t.ok(line.match(/.*hello world$/), 'end of line matches')
+    t.ok(line.match(/^INFO.*/), 'level is at start of line')
     t.ok(line.indexOf('' + process.pid) > 0, 'includes pid')
     t.ok(line.indexOf('' + hostname) > 0, 'includes hostname')
     return line

--- a/usage.txt
+++ b/usage.txt
@@ -9,8 +9,13 @@
 
      [33mcat log | pino -t[39m
 
+  To flip level and time/date in standard output use the [33m-l[39m flag[0m
+
+     [33mcat log | pino -l[39m
+
   [36m[1mFlags[22m[39m
   [0m-h | --help      Display Help
   -v | --version   Display Version
   -t               Convert Epoch timestamps to ISO[0m
+  -l               Flip level and date
 


### PR DESCRIPTION
Users can add `levelFirst: true` to the options passed in to pretty() to flip time and level around on the output line. 

e.g. 
`[2016-09-02T20:58:07.827Z] INFO (app/7776 .....` 
becomes 
`INFO [2016-09-02T20:46:21.237Z] (app/6868 ....`

Closes #81