### PR TITLE
handle undefined returned from toJSON

### DIFF
--- a/pino.js
+++ b/pino.js
@@ -238,9 +238,9 @@ Pino.prototype.asJson = function asJson (obj, msg, num) {
       for (var key in obj) {
         value = obj[key]
         if (obj.hasOwnProperty(key) && value !== undefined) {
-          value = this.serializers[key] ? this.serializers[key](value) : value
+          value = this.stringify(this.serializers[key] ? this.serializers[key](value) : value)
           if (value !== undefined) {
-            data += ',"' + key + '":' + this.stringify(value)
+            data += ',"' + key + '":' + value
           }
         }
       }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -292,6 +292,19 @@ test('correctly escape msg strings', function (t) {
   instance.fatal('this contains "')
 })
 
+test('correctly strip undefined when returned from toJSON', function (t) {
+  t.plan(1)
+
+  var instance = pino({
+    test: 'this'
+  }, sink(function (obj, enc, cb) {
+    t.notOk('test' in obj)
+    cb()
+  }))
+
+  instance.fatal({test: {toJSON: function () { return undefined }}})
+})
+
 test('correctly support node v4+ stderr', function (t) {
   t.plan(1)
 


### PR DESCRIPTION
For instance:

```js
instance.fatal({test: {toJSON: function () { return undefined }}})
```
Will give 

```json
{"pid":84573,"hostname":"x","level":30,"time":1475092820866,"test":undefined,"v":1}
```

If this log is later JSON.parsed it'll explode (unrecognized char 'u' error) 

