### PR TITLE
Support log message filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Returns a new logger. Allowed options are:
 * `extreme`: Enables extreme mode, yields an additional 60% performance (from 250ms down to 100ms per 10000 ops). There are trade-off's should be understood before usage. See [Extreme mode explained](#extreme). default `false`
 * `level`: one of `'fatal'`, `'error'`, `'warn'`, `'info`', `'debug'`, `'trace'`; also `'silent'` is supported to disable logging.
 * `enabled`: enables logging, defaults to `true`.
+* `filter`: A function which retrieves arguments just as they were passed to logging functions. Filter functions decide whether log messages should be formatted, serialized and logged, i.e. filter functions return a falsy value to discard log messages.
 
 `stream` is a Writable stream, defaults to `process.stdout`.
 

--- a/test/filtering.test.js
+++ b/test/filtering.test.js
@@ -1,0 +1,72 @@
+'use strict'
+
+var test = require('tap').test
+var pino = require('../')
+var sink = require('./helper').sink
+var check = require('./helper').check
+
+test('does not test filters when level is inactive', function (t) {
+  var filter = function () {
+    t.fail('Should should not be called.')
+  }
+
+  var instance = pino({filter: filter}, sink(function () {
+    t.fail('Should not downstream messages')
+  }))
+
+  instance.level = 'warn'
+  instance.info('')
+  t.end()
+})
+
+test('filters can reject messages', function (t) {
+  t.plan(4)
+
+  var filter = function (a) {
+    return a === 'a'
+  }
+  var expected = [{
+    level: 50,
+    msg: 'a'
+  }, {
+    level: 60,
+    msg: 'a'
+  }]
+
+  var instance = pino({filter: filter}, sink(function (chunk, enc, cb) {
+    var current = expected.shift()
+    check(t, chunk, current.level, current.msg)
+    cb()
+  }))
+
+  instance.error('a')
+  instance.warn('b')
+  instance.fatal('a')
+  t.end()
+})
+
+test('child loggers inherit filter from parent', function (t) {
+  t.plan(1)
+
+  var filter = function (a) {
+    return a === 'a'
+  }
+
+  var parent = pino({filter: filter}, sink(function (chunk, enc, cb) {
+    t.deepEqual(chunk, {
+      pid: chunk.pid,
+      hostname: chunk.hostname,
+      v: chunk.v,
+      time: chunk.time,
+      level: 60,
+      msg: 'a',
+      foo: 'bar'
+    })
+    cb()
+  }))
+
+  var child = parent.child({foo: 'bar'})
+  child.warn('b')
+  child.fatal('a')
+  t.end()
+})


### PR DESCRIPTION
Sometimes, especially when processing a large number of events /
requests, applications can go wild and start logging the same stuff
over and over again. It is desirable to filter messages in these
cases, so as to avoid filling up hard drives or to avoid exceeding
log aggregation limits. In other cases, sensitive information
could be filtered out.

This commit adds basic facilities for log message filtering. These
allow the registration of a log message filter which is applied
before (potentially) expensive formatting and serialization
tasks are executed. This is similar to other logging libraries
such as logback in the Java world.

In the end, I'd like to use this as the foundation for a duplicate log
message filter similar to one available in logback:

http://logback.qos.ch/manual/filters.html#DuplicateMessageFilter