### PR TITLE
fix typo split2

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,7 +820,7 @@ var myTransport = through.obj(function (chunk, enc, cb) {
   cb()
 })
 
-pump(process.stdin, split2(JSON.parse), myTransport)
+pump(process.stdin, split(JSON.parse), myTransport)
 ```
 
 ```sh


### PR DESCRIPTION
fix split2 is not defined error at transport example