### PR TITLE
Add support for multiple streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,36 @@ add. Regardless of the number, it will be slower than a regular `pino` instance.
 stream of the parent logger. This holds true for however many child loggers
 are created.
 
+**Stern warning:** the performance of this feature being dependent on the number
+of streams you supply cannot be overstated. This feature is being provided so
+that you can switch to `pino` from `Bunyan` and get some immediate improvement,
+but it is not meant to be a long term solution. We *strongly* suggest that you
+use this feature for only as long as it will take you to overhaul the way
+you handle logging in your application.
+
+To illustrate what we mean, here is a benchmark of `pino` and `Bunyan` using
+"multiple" streams to write to a single stream:
+
+```
+benchBunyanOne*10000: 875.099ms
+benchMSPinoOne*10000: 224.924ms
+```
+
+Now let's look at the same benchmark but increase the number of destination
+streams to four:
+
+```
+benchBunyanFour*10000: 3288.004ms
+benchMSPinoFour*10000: 722.918ms
+```
+
+And, finally, with ten destination streams:
+
+```
+benchBunyanTen*10000: 8142.875ms
+benchMSPinoTen*10000: 1992.805ms
+```
+
 
 <a name="extreme"></a>
 ## Extreme mode explained

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ INFO [2016-03-09T15:27:09.339Z] (14139 on MacBook-Pro-3.home): hello world
   * <a href="#resSerializer"><code>pino.stdSerializers.<b>res</b></code></a>
   * <a href="#errSerializer"><code>pino.stdSerializers.<b>err</b></code></a>
   * <a href="#pretty"><code>pino.<b>pretty()</b></code></a>
+  * <a href="#mspino"><code>require('pino/multi-stream')</code></a>
 
 
 <a name="constructor"></a>
@@ -563,6 +564,34 @@ log.child({ widget: 'foo' }).info('hello')
 log.child({ widget: 'bar' }).warn('hello 2')
 ```
 
+<a name="mspino"></a>
+### require('pino/multi-stream')
+
+Returns a `pino` <a href="#constructor">constructor</a> the supports an extra
+`streams` option that follows the same format as Bunyan. As an example:
+
+```js
+var fs = require('fs')
+var mspino = require('pino/multi-stream')
+var streams = [
+  {stream: fs.createWriteStream('/tmp/info.stream.out')},
+  {level: 'fatal', fs.createWriteStream('/tmp/fatal.stream.out')}
+]
+var log = mspino({streams: streams})
+
+log.info('this will be written to /tmp/info.stream.out')
+log.fatal('this will be written to /tmp/fatal.stream.out')
+```
+
+Caveats:
+
+* The speed of multi-stream `pino` is dependent upon the number of streams you
+add. Regardless of the number, it will be slower than a regular `pino` instance.
+* If you create child loggers then a new logger will be created for *each*
+stream of the parent logger. This holds true for however many child loggers
+are created.
+
+
 <a name="extreme"></a>
 ## Extreme mode explained
 
@@ -785,12 +814,12 @@ pino.info({
     to: {key: 'sensitive', another: 'thing'}
   },
   more: 'stuff'
-}) 
+})
 
 // {"pid":7306,"hostname":"x","level":30,"time":1475519922198,"key":"[Redacted]","path":{"to":{"key":"[Redacted]","another":"thing"}},"more":"stuff","v":1}
 ```
 
-If you have other serializers simply extend: 
+If you have other serializers simply extend:
 
 ```js
 var noir = require('pino-noir')

--- a/benchmarks/multi-stream.js
+++ b/benchmarks/multi-stream.js
@@ -28,7 +28,12 @@ var fourStreams = [
 ]
 var mspinoFour = mspino({streams: fourStreams})
 
-var max = 10
+var mspinoOne = mspino({streams: [{stream: dest}]})
+var blogOne = bunyan.createLogger({
+  name: 'myapp',
+  streams: [{stream: dest}]
+})
+
 var blogTen = bunyan.createLogger({
   name: 'myapp',
   streams: tenStreams
@@ -38,6 +43,7 @@ var blogFour = bunyan.createLogger({
   streams: fourStreams
 })
 
+var max = 10
 var run = bench([
   function benchBunyanTen (cb) {
     for (var i = 0; i < max; i++) {
@@ -72,6 +78,18 @@ var run = bench([
       mspinoFour.info('hello world')
       mspinoFour.debug('hello world')
       mspinoFour.trace('hello world')
+    }
+    setImmediate(cb)
+  },
+  function benchBunyanOne (cb) {
+    for (var i = 0; i < max; i++) {
+      blogOne.info('hello world')
+    }
+    setImmediate(cb)
+  },
+  function benchMSPinoOne (cb) {
+    for (var i = 0; i < max; i++) {
+      mspinoOne.info('hello world')
     }
     setImmediate(cb)
   }

--- a/benchmarks/multi-stream.js
+++ b/benchmarks/multi-stream.js
@@ -5,7 +5,8 @@ var bunyan = require('bunyan')
 var mspino = require('../multi-stream')
 var fs = require('fs')
 var dest = fs.createWriteStream('/dev/null')
-var streams = [
+
+var tenStreams = [
   {stream: dest},
   {stream: dest},
   {stream: dest},
@@ -17,28 +18,60 @@ var streams = [
   {level: 'warn', stream: dest},
   {level: 'fatal', stream: dest}
 ]
-var log = mspino({streams: streams})
+var mspinoTen = mspino({streams: tenStreams})
+
+var fourStreams = [
+  {stream: dest},
+  {stream: dest},
+  {level: 'debug', stream: dest},
+  {level: 'trace', stream: dest}
+]
+var mspinoFour = mspino({streams: fourStreams})
 
 var max = 10
-var blog = bunyan.createLogger({
+var blogTen = bunyan.createLogger({
   name: 'myapp',
-  streams: streams
+  streams: tenStreams
+})
+var blogFour = bunyan.createLogger({
+  name: 'myapp',
+  streams: fourStreams
 })
 
 var run = bench([
-  function benchBunyan (cb) {
+  function benchBunyanTen (cb) {
     for (var i = 0; i < max; i++) {
-      blog.info('hello world')
+      blogTen.info('hello world')
+      blogTen.debug('hello world')
+      blogTen.trace('hello world')
+      blogTen.warn('hello world')
+      blogTen.fatal('hello world')
     }
     setImmediate(cb)
   },
-  function benchMSPino (cb) {
+  function benchMSPinoTen (cb) {
     for (var i = 0; i < max; i++) {
-      log.info('hello world')
-      log.debug('hello world')
-      log.trace('hello world')
-      log.warn('hello world')
-      log.fatal('hello world')
+      mspinoTen.info('hello world')
+      mspinoTen.debug('hello world')
+      mspinoTen.trace('hello world')
+      mspinoTen.warn('hello world')
+      mspinoTen.fatal('hello world')
+    }
+    setImmediate(cb)
+  },
+  function benchBunyanFour (cb) {
+    for (var i = 0; i < max; i++) {
+      blogFour.info('hello world')
+      blogFour.debug('hello world')
+      blogFour.trace('hello world')
+    }
+    setImmediate(cb)
+  },
+  function benchMSPinoFour (cb) {
+    for (var i = 0; i < max; i++) {
+      mspinoFour.info('hello world')
+      mspinoFour.debug('hello world')
+      mspinoFour.trace('hello world')
     }
     setImmediate(cb)
   }

--- a/benchmarks/multi-stream.js
+++ b/benchmarks/multi-stream.js
@@ -1,0 +1,47 @@
+'use strict'
+
+var bench = require('fastbench')
+var bunyan = require('bunyan')
+var mspino = require('../multi-stream')
+var fs = require('fs')
+var dest = fs.createWriteStream('/dev/null')
+var streams = [
+  {stream: dest},
+  {stream: dest},
+  {stream: dest},
+  {stream: dest},
+  {stream: dest},
+  {level: 'debug', stream: dest},
+  {level: 'debug', stream: dest},
+  {level: 'trace', stream: dest},
+  {level: 'warn', stream: dest},
+  {level: 'fatal', stream: dest}
+]
+var log = mspino({streams: streams})
+
+var max = 10
+var blog = bunyan.createLogger({
+  name: 'myapp',
+  streams: streams
+})
+
+var run = bench([
+  function benchBunyan (cb) {
+    for (var i = 0; i < max; i++) {
+      blog.info('hello world')
+    }
+    setImmediate(cb)
+  },
+  function benchMSPino (cb) {
+    for (var i = 0; i < max; i++) {
+      log.info('hello world')
+      log.debug('hello world')
+      log.trace('hello world')
+      log.warn('hello world')
+      log.fatal('hello world')
+    }
+    setImmediate(cb)
+  }
+], 10000)
+
+run()

--- a/multi-stream.js
+++ b/multi-stream.js
@@ -42,7 +42,7 @@ function pino (opts, stream) {
       }
     }
   }
-  MSPino.prototype = Object.create(realPino.Pino.prototype)
+  MSPino.prototype = Object.create(realPino._Pino.prototype)
   MSPino.constructor = MSPino
 
   function genLog (level) {

--- a/multi-stream.js
+++ b/multi-stream.js
@@ -46,10 +46,37 @@ function pino (opts, stream) {
   MSPino.constructor = MSPino
 
   function genLog (level) {
-    return function LOG () {
-      for (var x = 0, y = this.loggers[level].length; x < y; x += 1) {
-        var logger = this.loggers[level][x]
-        logger[level].apply(logger, arguments)
+    return function LOG (arg1, arg2, arg3, arg4, arg5, arg6) {
+      for (var i = 0, j = this.loggers[level].length; i < j; i += 1) {
+        var logger = this.loggers[level][i]
+        var x
+        var args
+        switch (arguments.length) {
+          case 1:
+            logger[level](arg1)
+            break
+          case 2:
+            logger[level](arg1, arg2)
+            break
+          case 3:
+            logger[level](arg1, arg2, arg3)
+            break
+          case 4:
+            logger[level](arg1, arg2, arg3, arg4)
+            break
+          case 5:
+            logger[level](arg1, arg2, arg3, arg4, arg5)
+            break
+          case 6:
+            logger[level](arg1, arg2, arg3, arg4, arg5, arg6)
+            break
+          default:
+            args = [arg1, arg2, arg3, arg4, arg5, arg6]
+            for (x = 7; x < arguments.length; x += 1) {
+              args[x - 1] = arguments[x]
+            }
+            logger[level].apply(logger, args)
+        }
       }
     }
   }

--- a/multi-stream.js
+++ b/multi-stream.js
@@ -1,0 +1,86 @@
+'use strict'
+
+var realPino = require('./pino')
+var noop = require('./noop')
+
+function pino (opts, stream) {
+  if (opts && (opts.writable || opts._writableState)) {
+    return realPino(null, opts)
+  }
+
+  if (opts.hasOwnProperty('stream') === true) {
+    return realPino(opts, opts.stream)
+  }
+
+  if (opts.hasOwnProperty('streams') === false) {
+    return realPino(opts, stream)
+  }
+
+  if (Array.isArray(opts.streams) === false) {
+    return realPino(opts, opts.streams)
+  }
+
+  var streams = opts.streams
+  var loggers = {}
+  for (var i = 0, j = streams.length; i < j; i += 1) {
+    var _opts = Object.create(opts)
+    var s = streams[i]
+    _opts.level = (s.level) ? s.level : 'info'
+    if (loggers[_opts.level]) {
+      loggers[_opts.level].push(realPino(_opts, s.stream))
+    } else {
+      loggers[_opts.level] = [realPino(_opts, s.stream)]
+    }
+  }
+
+  function MSPino (_loggers) {
+    this.loggers = _loggers
+  }
+  MSPino.prototype = Object.create(realPino.Pino.prototype)
+  MSPino.constructor = MSPino
+
+  function doLog (logger, level, params) {
+    logger[level].apply(logger, params)
+  }
+  MSPino.prototype._issueLog = function issueLog (level, params) {
+    if (!this.loggers[level]) return noop()
+    for (var i = 0, j = this.loggers[level].length; i < j; i += 1) {
+      doLog(this.loggers[level][i], level, params)
+    }
+  }
+
+  MSPino.prototype.fatal = function fatal () {
+    this._issueLog('fatal', arguments)
+  }
+  MSPino.prototype.error = function error () {
+    this._issueLog('error', arguments)
+  }
+  MSPino.prototype.warn = function warn () {
+    this._issueLog('warn', arguments)
+  }
+  MSPino.prototype.info = function info () {
+    this._issueLog('info', arguments)
+  }
+  MSPino.prototype.debug = function debug () {
+    this._issueLog('debug', arguments)
+  }
+  MSPino.prototype.trace = function trace () {
+    this._issueLog('trace', arguments)
+  }
+  MSPino.prototype.child = function child (bindings) {
+    var levels = Object.keys(this.loggers)
+    var childLoggers = {}
+    for (var i = 0, j = levels.length; i < j; i += 1) {
+      childLoggers[levels[i]] = []
+      for (var x = 0, y = this.loggers[levels[i]].length; x < y; x += 1) {
+        var log = this.loggers[levels[i]][x]
+        childLoggers[levels[i]].push(log.child(bindings))
+      }
+    }
+    return new MSPino(childLoggers)
+  }
+
+  return new MSPino(loggers)
+}
+
+module.exports = pino

--- a/pino.js
+++ b/pino.js
@@ -415,6 +415,7 @@ module.exports.stdSerializers = {
   res: asResValue,
   err: asErrValue
 }
+module.exports.Pino = Pino
 module.exports.pretty = require('./pretty')
 Object.defineProperty(
   module.exports,

--- a/test/multi-stream.test.js
+++ b/test/multi-stream.test.js
@@ -36,7 +36,7 @@ test('supports multiple arguments', function (t) {
       t.is(msg1.msg, 'foo bar baz foobar')
 
       var msg2 = messages[1]
-      t.is(msg2.msg, 'foo bar baz foobar barfoo')
+      t.is(msg2.msg, 'foo bar baz foobar barfoo foofoo')
 
       t.done()
     }
@@ -44,7 +44,7 @@ test('supports multiple arguments', function (t) {
   })
   var log = mspino({streams: stream})
   log.info('%s %s %s %s', 'foo', 'bar', 'baz', 'foobar') // apply not invoked
-  log.info('%s %s %s %s %s', 'foo', 'bar', 'baz', 'foobar', 'barfoo') // apply invoked
+  log.info('%s %s %s %s %s %s', 'foo', 'bar', 'baz', 'foobar', 'barfoo', 'foofoo') // apply invoked
 })
 
 test('supports children', function (t) {

--- a/test/multi-stream.test.js
+++ b/test/multi-stream.test.js
@@ -27,6 +27,26 @@ test('sends to multiple streams', function (t) {
   log.fatal('fatal stream')
 })
 
+test('supports multiple arguments', function (t) {
+  var messages = []
+  var stream = writeStream(function (data, enc, cb) {
+    messages.push(JSON.parse(data))
+    if (messages.length === 2) {
+      var msg1 = messages[0]
+      t.is(msg1.msg, 'foo bar baz foobar')
+
+      var msg2 = messages[1]
+      t.is(msg2.msg, 'foo bar baz foobar barfoo')
+
+      t.done()
+    }
+    cb()
+  })
+  var log = mspino({streams: stream})
+  log.info('%s %s %s %s', 'foo', 'bar', 'baz', 'foobar') // apply not invoked
+  log.info('%s %s %s %s %s', 'foo', 'bar', 'baz', 'foobar', 'barfoo') // apply invoked
+})
+
 test('supports children', function (t) {
   var stream = writeStream(function (data, enc, cb) {
     var input = JSON.parse(data)

--- a/test/multi-stream.test.js
+++ b/test/multi-stream.test.js
@@ -1,0 +1,63 @@
+'use strict'
+
+var fs = require('fs')
+var test = require('tap').test
+var mspino = require('../multi-stream')
+
+test('sends to multiple streams', function (t) {
+  var streams = [
+    {stream: fs.createWriteStream('/tmp/info.out')},
+    {level: 'debug', stream: fs.createWriteStream('/tmp/debug.out')},
+    {level: 'fatal', stream: fs.createWriteStream('/tmp/fatal.out')}
+  ]
+  var log = mspino({streams: streams})
+  log.info('info stream')
+  log.debug('debug stream')
+  log.fatal('fatal stream')
+
+  setImmediate(function () {
+    var res = JSON.parse(fs.readFileSync('/tmp/info.out'))
+    t.is(res.msg, 'info stream')
+
+    res = JSON.parse(fs.readFileSync('/tmp/debug.out'))
+    t.is(res.msg, 'debug stream')
+
+    res = JSON.parse(fs.readFileSync('/tmp/fatal.out'))
+    t.is(res.msg, 'fatal stream')
+
+    t.done()
+  })
+})
+
+test('supports children', function (t) {
+  var streams = [
+    {stream: fs.createWriteStream('/tmp/multichild.out')}
+  ]
+  var log = mspino({streams: streams}).child({child: 'one'})
+  log.info('child stream')
+
+  setImmediate(function () {
+    var res = JSON.parse(fs.readFileSync('/tmp/multichild.out'))
+    t.is(res.msg, 'child stream')
+    t.is(res.child, 'one')
+
+    t.done()
+  })
+})
+
+test('supports grandchildren', function (t) {
+  var streams = [
+    {stream: fs.createWriteStream('/tmp/multigrandchild.out')}
+  ]
+  var log = mspino({streams: streams}).child({child: 'one'}).child({grandchild: 'two'})
+  log.info('grandchild stream')
+
+  setImmediate(function () {
+    var res = JSON.parse(fs.readFileSync('/tmp/multigrandchild.out'))
+    t.is(res.msg, 'grandchild stream')
+    t.is(res.child, 'one')
+    t.is(res.grandchild, 'two')
+
+    t.done()
+  })
+})


### PR DESCRIPTION
This PR adds a wrapper around `pino` that allows multiple destination streams to be specified. Example (from the readme):

```js
var fs = require('fs')
var mspino = require('pino/multi-stream')
var streams = [
  {stream: fs.createWriteStream('/tmp/info.stream.out')},
  {level: 'fatal', fs.createWriteStream('/tmp/fatal.stream.out')}
]
var log = mspino({streams: streams})

log.info('this will be written to /tmp/info.stream.out')
log.fatal('this will be written to /tmp/fatal.stream.out')
```

This further increases the compatibility with the Bunyan API. It does, however, come with significant cost. On my machine, the included benchmark, which goes to 10 destination streams, run three consecutive times results in:

```
benchBunyan*10000: 1835.647ms
benchMSPino*10000: 1605.660ms

benchBunyan*10000: 1945.961ms
benchMSPino*10000: 1643.411ms

benchBunyan*10000: 1909.204ms
benchMSPino*10000: 1684.122ms
```

I'm sure the code can be improved, but I wanted to get feedback on if it should be included or not before thinking too hard on it. What do you think @mcollina and @davidmarkclements ?