### PR TITLE
Newlines aren't handled correctly

### DIFF
--- a/pino.js
+++ b/pino.js
@@ -201,25 +201,6 @@ Object.defineProperty(
   {value: LOG_VERSION}
 )
 
-function fastRep (s) {
-  var str = s.toString()
-  var result = ''
-  var last = 0
-  var l = str.length
-  for (var i = 0; i < l; i++) {
-    if (str[i] === '"') {
-      result += str.slice(last, i) + '\\"'
-      last = i + 1
-    }
-  }
-  if (last === 0) {
-    result = str
-  } else {
-    result += str.slice(last)
-  }
-  return result
-}
-
 Pino.prototype.asJson = function asJson (obj, msg, num) {
   if (!msg && obj instanceof Error) {
     msg = obj.message
@@ -228,7 +209,7 @@ Pino.prototype.asJson = function asJson (obj, msg, num) {
   // to catch both null and undefined
   /* eslint-disable eqeqeq */
   if (msg != undefined) {
-    data += ',"msg":"' + fastRep(msg) + '"'
+    data += ',"msg":' + JSON.stringify(msg)
   }
   var value
   if (obj) {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -328,3 +328,24 @@ test('correctly support node v4+ stderr', function (t) {
 
   instance.fatal('a message')
 })
+
+test('correctly escape \\n', function (t) {
+  t.plan(1)
+
+  var instance = pino({
+    name: 'hello'
+  }, sink(function (chunk, enc, cb) {
+    delete chunk.time
+    t.deepEqual(chunk, {
+      pid: pid,
+      hostname: hostname,
+      level: 60,
+      name: 'hello',
+      msg: 'this contains \n',
+      v: 1
+    })
+    cb()
+  }))
+
+  instance.fatal('this contains \n')
+})

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -272,24 +272,65 @@ test('throw if creating child without bindings', function (t) {
 })
 
 test('correctly escape msg strings', function (t) {
-  t.plan(1)
+  // These characters must be escaped according to the JSON spec
+  // Reference: https://tools.ietf.org/html/rfc7159#section-7
+  var mustEscape = [
+    '\u0000', // NUL  Null character
+    '\u0001', // SOH  Start of Heading
+    '\u0002', // STX  Start of Text
+    '\u0003', // ETX  End-of-text character
+    '\u0004', // EOT  End-of-transmission character
+    '\u0005', // ENQ  Enquiry character
+    '\u0006', // ACK  Acknowledge character
+    '\u0007', // BEL  Bell character
+    '\u0008', // BS   Backspace
+    '\u0009', // HT   Horizontal tab
+    '\u000A', // LF   Line feed
+    '\u000B', // VT   Vertical tab
+    '\u000C', // FF   Form feed
+    '\u000D', // CR   Carriage return
+    '\u000E', // SO   Shift Out
+    '\u000F', // SI   Shift In
+    '\u0010', // DLE  Data Link Escape
+    '\u0011', // DC1  Device Control 1
+    '\u0012', // DC2  Device Control 2
+    '\u0013', // DC3  Device Control 3
+    '\u0014', // DC4  Device Control 4
+    '\u0015', // NAK  Negative-acknowledge character
+    '\u0016', // SYN  Synchronous Idle
+    '\u0017', // ETB  End of Transmission Block
+    '\u0018', // CAN  Cancel character
+    '\u0019', // EM   End of Medium
+    '\u001A', // SUB  Substitute character
+    '\u001B', // ESC  Escape character
+    '\u001C', // FS   File Separator
+    '\u001D', // GS   Group Separator
+    '\u001E', // RS   Record Separator
+    '\u001F', // US   Unit Separator
+    '\u0022', // "    Quotation mark
+    '\u005C'  // \    Reverse solidus
+  ]
 
-  var instance = pino({
-    name: 'hello'
-  }, sink(function (chunk, enc, cb) {
-    delete chunk.time
-    t.deepEqual(chunk, {
-      pid: pid,
-      hostname: hostname,
-      level: 60,
-      name: 'hello',
-      msg: 'this contains "',
-      v: 1
-    })
-    cb()
-  }))
+  t.plan(mustEscape.length)
 
-  instance.fatal('this contains "')
+  mustEscape.forEach(function (character) {
+    var instance = pino({
+      name: 'hello'
+    }, sink(function (chunk, enc, cb) {
+      delete chunk.time
+      t.deepEqual(chunk, {
+        pid: pid,
+        hostname: hostname,
+        level: 60,
+        name: 'hello',
+        msg: 'this contains ' + character,
+        v: 1
+      })
+      cb()
+    }))
+
+    instance.fatal('this contains ' + character)
+  })
 })
 
 test('correctly strip undefined when returned from toJSON', function (t) {
@@ -327,25 +368,4 @@ test('correctly support node v4+ stderr', function (t) {
   var instance = pino(dest)
 
   instance.fatal('a message')
-})
-
-test('correctly escape \\n', function (t) {
-  t.plan(1)
-
-  var instance = pino({
-    name: 'hello'
-  }, sink(function (chunk, enc, cb) {
-    delete chunk.time
-    t.deepEqual(chunk, {
-      pid: pid,
-      hostname: hostname,
-      level: 60,
-      name: 'hello',
-      msg: 'this contains \n',
-      v: 1
-    })
-    cb()
-  }))
-
-  instance.fatal('this contains \n')
 })


### PR DESCRIPTION
*I apologize for creating PR without a solution here, but I didn't want to just create an issue that didn't have some more substantial data attached, and figured a PR would be an easier read than a bunch of code snippets. Perhaps this PR can turn into a solution – it's just not apparent to me at this stage.*

New lines don't seem to be serialized correctly. The test added in this PR breaks, when the stream tries parsing the chunk. For some reason – I don't know it yet – adding a `\n` seemingly anywhere in the message will produce invalid JSON which is then written to the output stream. I *think* it's because of `fastRep`, but haven't been able to verify this. I'm hoping by showing you this, maybe it'll be apparent to you what the problem is, and we can work together to resolve it. In the meantime, I'll try to figure this out as well.

This test shows a trailing newline, but it happens with newlines *anywhere* in the message string.